### PR TITLE
Fix compiler warnings

### DIFF
--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -376,8 +376,8 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                   opened, remove it and try again (this option\n\
                                   is ignored when the -n option is also used)\n\
 +  -g, --progress-bar           add a progress bar.\n\
-+                                 Note that this doesn't work with reflink,\n\ 
-+                                 reflink will be automatically disabled\n\ 
++                                 Note that this doesn't work with reflink,\n\
++                                 reflink will be automatically disabled\n\
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\


### PR DESCRIPTION
This pull request fixes the following compiler warnings:

```
src/cp.c: In function 'usage':
src/cp.c:175:77: warning: backslash and newline separated by space
  175 |                                  Note that this doesn't work with reflink,\n\
      |
src/cp.c:176:74: warning: backslash and newline separated by space
  176 |                                  reflink will be automatically disabled\n\
      |
```