### PR TITLE
fix compiler warning for 0.9 patch

### DIFF
--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -158,7 +158,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +            {
 +              printf ( "\033[K%s\n", s_progress->cProgressField[it] );
 +              if ( strlen ( s_progress->cProgressField[it] ) < s_progress->iBarLength )
-+                printf ( "" );
++                printf ( "%s", "" );
 +            }
 +            if ( g_iTotalFiles > 1 )
 +              printf ( "\r\033[6A" );


### PR DESCRIPTION
There seems to be a regression, where the 0.9-9.0 path has the compiler warning  again, which was fixed before for the older patch.