### PR TITLE
Fix and Improvements

### DIFF
--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.c	2021-12-25 11:18:23.578451391 +0100
-@@ -129,6 +129,95 @@
++++ coreutils-8.32-patched/src/copy.c	2022-01-04 21:56:14.545035647 +0100
+@@ -129,6 +129,119 @@
    dev_t dev;
  };
  
@@ -37,6 +37,30 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +  ipos++;
 +  _cEscapedString[ipos] = '\0';
 +  return _cEscapedString;
++}
++
++char * format_elapsed_time ( double sec_elapsed )
++{
++  // hours
++  long hr = ( (int) sec_elapsed / (60 * 60)) % 24;
++  // minutes
++  int min = ( (int) sec_elapsed / 60) % 60;
++  // seconds
++  double sec = sec_elapsed - (hr * (60 * 60)) - (min * 60);
++  size_t maxneeded = snprintf(NULL, 0, "%ldh %dm %.1fs", hr, min, sec) + 1;
++  char * _cElapsedTimeString;
++  _cElapsedTimeString = (char *) calloc( sizeof(char) * maxneeded, sizeof(char) );
++  if ( sec_elapsed >= 3600 )
++  {
++    sprintf(_cElapsedTimeString, "%ldh %dm %.1fs", hr, min, sec);
++  } else if ( sec_elapsed >= 60 )
++  {
++    sprintf(_cElapsedTimeString, "%dm %.1fs", min, sec);
++  } else
++  {
++    sprintf(_cElapsedTimeString, "%.1fs", sec);
++  }
++  return _cElapsedTimeString;
 +}
 +
 +static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
@@ -97,7 +121,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -259,9 +348,16 @@
+@@ -259,9 +372,16 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes,
@@ -115,7 +139,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -270,6 +366,85 @@
+@@ -270,6 +390,85 @@
  
    while (max_n_read)
      {
@@ -201,7 +225,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -354,6 +529,14 @@
+@@ -354,6 +553,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -216,21 +240,25 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -420,9 +603,11 @@
- static bool
+@@ -421,8 +628,16 @@
  extent_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, off_t src_total_size,
--             enum Sparse_type sparse_mode,
-+             enum Sparse_type sparse_mode, bool move_mode,
+              enum Sparse_type sparse_mode,
++             /* BEGIN progress mod */
++             bool move_mode,
++             /* END progress mod */
               char const *src_name, char const *dst_name,
 -             bool *require_normal_copy)
-+             bool *require_normal_copy,
-+             int iCountDown, char ** cProgressField, struct timeval last_time,
-+             int last_size, int iBarLength, struct stat src_open_sb)
++             bool *require_normal_copy
++             /* BEGIN progress mod */
++             , int iCountDown, char ** cProgressField, struct timeval last_time,
++             int last_size, int iBarLength, struct stat src_open_sb
++             /* END progress mod */
++             )
  {
    struct extent_scan scan;
    off_t last_ext_start = 0;
-@@ -553,10 +738,26 @@
+@@ -553,10 +768,26 @@
                last_ext_len = ext_len;
                bool read_hole;
  
@@ -259,7 +287,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
                  goto fail;
  
                dest_pos = ext_start + n_read;
-@@ -1305,6 +1506,75 @@
+@@ -1305,6 +1536,75 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -335,18 +363,24 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        if (sparse_src)
          {
            bool normal_copy_required;
-@@ -1316,7 +1586,9 @@
+@@ -1316,7 +1616,15 @@
            if (extent_copy (source_desc, dest_desc, buf, buf_size, hole_size,
                             src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
 -                           src_name, dst_name, &normal_copy_required))
-+                           x->move_mode, src_name, dst_name, &normal_copy_required,
-+                           iCountDown, cProgressField, last_time, last_size,
-+                           iBarLength, src_open_sb))
++                           /* BEGIN progress mod */
++                           x->move_mode,
++                           /* END progress mod */
++                           src_name, dst_name, &normal_copy_required
++                           /* BEGIN progress mod */
++                           , iCountDown, cProgressField, last_time, last_size,
++                           iBarLength, src_open_sb
++                           /* END progress mod */
++                           ))
              goto preserve_metadata;
  
            if (! normal_copy_required)
-@@ -1328,11 +1600,23 @@
+@@ -1328,11 +1636,24 @@
  
        off_t n_read;
        bool wrote_hole_at_eof;
@@ -358,13 +392,13 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        if (! sparse_copy (source_desc, dest_desc, buf, buf_size,
                           make_holes ? hole_size : 0,
 -                         x->sparse_mode == SPARSE_ALWAYS, src_name, dst_name,
--                         UINTMAX_MAX, &n_read,
--                         &wrote_hole_at_eof))
 +                         x->sparse_mode == SPARSE_ALWAYS,
 +                         /* BEGIN progress mod */
 +                         x->move_mode,
 +                         /* END progress mod */
-+                         src_name, dst_name, UINTMAX_MAX, &n_read,
++                         src_name, dst_name,
+                          UINTMAX_MAX, &n_read,
+-                         &wrote_hole_at_eof))
 +                         &wrote_hole_at_eof
 +                         /* BEGIN progress mod */
 +                         , &s_progress
@@ -373,7 +407,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1343,6 +1627,14 @@
+@@ -1343,6 +1664,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -388,14 +422,16 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
      }
  
  preserve_metadata:
-@@ -1716,15 +2008,15 @@
+@@ -1716,15 +2045,19 @@
        fprintf (stderr,
                 (x->move_mode || x->unlink_dest_before_opening
                  || x->unlink_dest_after_failed_open)
 -               ? _("%s: replace %s, overriding mode %04lo (%s)? ")
 -               : _("%s: unwritable %s (mode %04lo, %s); try anyway? "),
++               /* BEGIN progress mod - remove \n\n in string!*/
 +               ? _("\n\n%s: replace %s, overriding mode %04lo (%s)? ")
 +               : _("\n\n%s: unwritable %s (mode %04lo, %s); try anyway? "),
++               /* END progress mod */
                 program_name, quoteaf (dst_name),
                 (unsigned long int) (dst_sb->st_mode & CHMOD_MODE_BITS),
                 &perms[1]);
@@ -403,13 +439,15 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
    else
      {
 -      fprintf (stderr, _("%s: overwrite %s? "),
++      /* BEGIN progress mod - remove \n\n in string!*/
 +      fprintf (stderr, _("\n\n%s: overwrite %s? "),
++      /* END progress mod - remove \n\n in string!*/
                 program_name, quoteaf (dst_name));
      }
  
 diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
 --- coreutils-8.32/src/copy.h	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.h	2021-12-23 12:24:33.256775516 +0100
++++ coreutils-8.32-patched/src/copy.h	2022-01-04 21:56:14.545035647 +0100
 @@ -234,6 +234,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -422,12 +460,13 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -304,4 +309,18 @@
+@@ -304,4 +309,19 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
 +/* BEGIN progress mod */
 +char * escape_double_quotes ( char * _cUnescapedString );
++char * format_elapsed_time ( double sec_elapsed );
 +
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
@@ -443,7 +482,7 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
  #endif
 diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 --- coreutils-8.32/src/cp.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/cp.c	2021-12-25 11:20:32.070133977 +0100
++++ coreutils-8.32-patched/src/cp.c	2022-01-04 21:56:14.545035647 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -598,23 +637,25 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +          sprintf ( sFType, "%s", "folder(s)/file(s)" );
 +        else
 +          sprintf ( sFType, "%s", "file(s)" );
-+        printf ( "%d %s (%s) copied in %.1f seconds (%s/s).\n", g_iFilesCopied, sFType,
-+                 sTotalWritten, sec_elapsed, s_copy_speed );
++        printf ( "%d %s (%s) copied in %s (%s/s).\n", g_iFilesCopied, sFType,
++                 sTotalWritten, format_elapsed_time(sec_elapsed), s_copy_speed );
 +    }
 +    /* END progress mod */
 +
    return ok;
  }
  
-@@ -812,6 +946,7 @@
+@@ -812,6 +946,9 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
++  /* BEGIN progress mod */
 +  x->progress_bar = false;
++  /* END progress mod */
    x->set_mode = false;
    x->mode = 0;
  
-@@ -950,7 +1085,8 @@
+@@ -950,7 +1087,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -624,7 +665,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1007,6 +1143,12 @@
+@@ -1007,6 +1145,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
@@ -639,7 +680,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
            break;
 diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 --- coreutils-8.32/src/mv.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/mv.c	2021-12-23 19:31:05.335749444 +0100
++++ coreutils-8.32-patched/src/mv.c	2022-01-04 21:56:14.549035719 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -763,8 +804,8 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 +        sprintf ( sFType, "%s", "folder(s)/file(s)" );
 +      else
 +        sprintf ( sFType, "%s", "file(s)" );
-+      printf ( "%d %s (%s) moved in %.1f seconds (%s/s).\n", g_iFilesCopied, sFType,
-+               sTotalWritten, sec_elapsed, s_copy_speed );
++      printf ( "%d %s (%s) moved in %s (%s/s).\n", g_iFilesCopied, sFType,
++               sTotalWritten, format_elapsed_time(sec_elapsed), s_copy_speed );
 +    }
 +  }
 +  /* END progress mod */

--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,6 +1,6 @@
-diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
+diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.c	2022-02-14 21:10:42.216002503 +0100
++++ coreutils-8.32-patched-nc/src/copy.c	2022-02-14 21:14:14.171156659 +0100
 @@ -129,6 +129,133 @@
    dev_t dev;
  };
@@ -135,21 +135,17 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -259,17 +386,129 @@
+@@ -258,18 +385,124 @@
+    bytes read.  */
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
-              size_t hole_size, bool punch_holes,
-+             /* BEGIN progress mod */
-+             bool move_mode,
-+             /* END progress mod */
+-             size_t hole_size, bool punch_holes,
++             size_t hole_size, bool punch_holes, bool move_mode,
               char const *src_name, char const *dst_name,
               uintmax_t max_n_read, off_t *total_n_read,
 -             bool *last_write_made_hole)
-+             bool *last_write_made_hole
-+             /* BEGIN progress mod */
-+             , struct progress_status *s_progress
-+             /* END progress mod */
-+             )
++             bool *last_write_made_hole,
++             struct progress_status *s_progress)
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
@@ -266,7 +262,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -354,6 +593,14 @@
+@@ -354,6 +587,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -281,54 +277,40 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -421,8 +668,16 @@
+@@ -420,9 +661,11 @@
+ static bool
  extent_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, off_t src_total_size,
-              enum Sparse_type sparse_mode,
-+             /* BEGIN progress mod */
-+             bool move_mode,
-+             /* END progress mod */
+-             enum Sparse_type sparse_mode,
++             enum Sparse_type sparse_mode, bool move_mode,
               char const *src_name, char const *dst_name,
 -             bool *require_normal_copy)
-+             bool *require_normal_copy
-+             /* BEGIN progress mod */
-+             , int iCountDown, char ** cProgressField, struct timeval last_time,
-+             int last_size, int iBarLength, struct stat src_open_sb
-+             /* END progress mod */
-+             )
++             bool *require_normal_copy,
++             int iCountDown, char ** cProgressField, struct timeval last_time,
++             int last_size, int iBarLength, struct stat src_open_sb)
  {
    struct extent_scan scan;
    off_t last_ext_start = 0;
-@@ -553,10 +808,26 @@
+@@ -553,10 +796,16 @@
                last_ext_len = ext_len;
                bool read_hole;
  
-+              /* BEGIN progress mod */
 +              struct timeval a;
 +              struct stat b;
 +
 +              struct progress_status s_progress={iCountDown, cProgressField, last_time, last_size, iBarLength, src_open_sb};
-+              /* END progress mod */
 +
 +
                if ( ! sparse_copy (src_fd, dest_fd, buf, buf_size,
                                    sparse_mode == SPARSE_ALWAYS ? hole_size: 0,
 -                                  true, src_name, dst_name, ext_len, &n_read,
 -                                  &read_hole))
-+                                  true,
-+                                  /* BEGIN progress mod */
-+                                  move_mode,
-+                                  /* END progress mod */
-+                                  src_name, dst_name, ext_len, &n_read,
-+                                  &read_hole
-+                                  /* BEGIN progress mod */
-+                                  ,&s_progress
-+                                  /* END progress mod */
-+                                  ))
++                                  true, move_mode, src_name, dst_name, ext_len,
++                                  &n_read, &read_hole, &s_progress))
                  goto fail;
  
                dest_pos = ext_start + n_read;
-@@ -1305,6 +1576,75 @@
+@@ -1305,6 +1554,75 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -404,75 +386,56 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        if (sparse_src)
          {
            bool normal_copy_required;
-@@ -1316,7 +1656,15 @@
+@@ -1316,7 +1634,9 @@
            if (extent_copy (source_desc, dest_desc, buf, buf_size, hole_size,
                             src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
 -                           src_name, dst_name, &normal_copy_required))
-+                           /* BEGIN progress mod */
-+                           x->move_mode,
-+                           /* END progress mod */
-+                           src_name, dst_name, &normal_copy_required
-+                           /* BEGIN progress mod */
-+                           , iCountDown, cProgressField, last_time, last_size,
-+                           iBarLength, src_open_sb
-+                           /* END progress mod */
-+                           ))
++                           x->move_mode, src_name, dst_name, &normal_copy_required,
++                           iCountDown, cProgressField, last_time, last_size,
++                           iBarLength, src_open_sb))
              goto preserve_metadata;
  
            if (! normal_copy_required)
-@@ -1328,11 +1676,24 @@
+@@ -1328,11 +1648,14 @@
  
        off_t n_read;
        bool wrote_hole_at_eof;
 +
-+      /* BEGIN progress mod */
 +      struct progress_status s_progress = { iCountDown, cProgressField, last_time, last_size, iBarLength, src_open_sb};
-+      /* END progress mod */
 +
        if (! sparse_copy (source_desc, dest_desc, buf, buf_size,
                           make_holes ? hole_size : 0,
 -                         x->sparse_mode == SPARSE_ALWAYS, src_name, dst_name,
-+                         x->sparse_mode == SPARSE_ALWAYS,
-+                         /* BEGIN progress mod */
-+                         x->move_mode,
-+                         /* END progress mod */
-+                         src_name, dst_name,
-                          UINTMAX_MAX, &n_read,
+-                         UINTMAX_MAX, &n_read,
 -                         &wrote_hole_at_eof))
-+                         &wrote_hole_at_eof
-+                         /* BEGIN progress mod */
-+                         , &s_progress
-+                         /* END progress mod */
-+                         ))
++                         x->sparse_mode == SPARSE_ALWAYS, x->move_mode,
++                         src_name, dst_name, UINTMAX_MAX, &n_read,
++                         &wrote_hole_at_eof, &s_progress))
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1343,6 +1704,14 @@
+@@ -1343,6 +1666,12 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
-+      /* BEGIN progress mod */
 +      if (progress) {
 +            int i;
 +            for ( i = 0; i < 6; i++ )
 +              free ( cProgressField[i] );
 +            free ( cProgressField );
 +      }
-+      /* END progress mod */
      }
  
  preserve_metadata:
-@@ -1716,15 +2085,19 @@
+@@ -1716,15 +2045,15 @@
        fprintf (stderr,
                 (x->move_mode || x->unlink_dest_before_opening
                  || x->unlink_dest_after_failed_open)
 -               ? _("%s: replace %s, overriding mode %04lo (%s)? ")
 -               : _("%s: unwritable %s (mode %04lo, %s); try anyway? "),
-+               /* BEGIN progress mod - remove \n\n in string!*/
 +               ? _("\n\n%s: replace %s, overriding mode %04lo (%s)? ")
 +               : _("\n\n%s: unwritable %s (mode %04lo, %s); try anyway? "),
-+               /* END progress mod */
                 program_name, quoteaf (dst_name),
                 (unsigned long int) (dst_sb->st_mode & CHMOD_MODE_BITS),
                 &perms[1]);
@@ -480,28 +443,24 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
    else
      {
 -      fprintf (stderr, _("%s: overwrite %s? "),
-+      /* BEGIN progress mod - remove \n\n in string!*/
 +      fprintf (stderr, _("\n\n%s: overwrite %s? "),
-+      /* END progress mod - remove \n\n in string!*/
                 program_name, quoteaf (dst_name));
      }
  
-diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
+diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched-nc/src/copy.h
 --- coreutils-8.32/src/copy.h	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.h	2022-02-14 21:10:42.220002638 +0100
-@@ -234,6 +234,11 @@
++++ coreutils-8.32-patched-nc/src/copy.h	2022-02-14 21:14:14.175156795 +0100
+@@ -234,6 +234,9 @@
       Create destination directories as usual. */
    bool symbolic_link;
  
-+  /* BEGIN progress mod */
 +  /* If true, draw a nice progress bar on screen */
 +  bool progress_bar;
-+  /* END progress mod */
 +
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -304,4 +309,22 @@
+@@ -304,4 +307,22 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
@@ -524,34 +483,28 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
 +/* END progress mod */
 +
  #endif
-diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
+diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched-nc/src/cp.c
 --- coreutils-8.32/src/cp.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/cp.c	2022-02-14 21:10:42.220002638 +0100
-@@ -131,6 +131,9 @@
++++ coreutils-8.32-patched-nc/src/cp.c	2022-02-14 21:14:14.175156795 +0100
+@@ -131,6 +131,7 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
-+  /* BEGIN progress mod */
 +  {"progress-bar", no_argument, NULL, 'g'},
-+  /* END progress mod */
    {"verbose", no_argument, NULL, 'v'},
    {GETOPT_SELINUX_CONTEXT_OPTION_DECL},
    {GETOPT_HELP_OPTION_DECL},
-@@ -170,6 +173,13 @@
+@@ -170,6 +171,9 @@
    -f, --force                  if an existing destination file cannot be\n\
                                   opened, remove it and try again (this option\n\
                                   is ignored when the -n option is also used)\n\
-+"), stdout); /* BEGIN progress mod - remove the complete line!*/
-+      fputs (_("\
 +  -g, --progress-bar           add a progress bar.\n\
 +                                 Note that this doesn't work with reflink,\n\
 +                                 reflink will be automatically disabled\n\
-+"), stdout);
-+/* END progress mod - remove the complete line!*/ fputs (_("\
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -635,6 +645,84 @@
+@@ -635,6 +639,84 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
@@ -636,7 +589,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
  
    if (target_directory)
      {
-@@ -777,6 +865,56 @@
+@@ -777,6 +859,56 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -693,55 +646,46 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
    return ok;
  }
  
-@@ -812,6 +950,11 @@
+@@ -812,6 +944,7 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
-+
-+  /* BEGIN progress mod */
 +  x->progress_bar = false;
-+  /* END progress mod */
-+
    x->set_mode = false;
    x->mode = 0;
  
-@@ -950,7 +1093,8 @@
+@@ -950,7 +1083,7 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
 -  while ((c = getopt_long (argc, argv, "abdfHilLnprst:uvxPRS:TZ",
-+  /* BEGIN and END progress mod - remove the g in the next line!*/
 +  while ((c = getopt_long (argc, argv, "abdfgHilLnprst:uvxPRS:TZ",
                             long_opts, NULL))
           != -1)
      {
-@@ -1007,6 +1151,12 @@
+@@ -1007,6 +1140,10 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
-+        /* BEGIN progress mod */
 +        case 'g':
 +          progress = true;
 +          break;
-+        /* END progress mod */
 +
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
+diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched-nc/src/mv.c
 --- coreutils-8.32/src/mv.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/mv.c	2022-02-14 21:10:42.220002638 +0100
-@@ -66,6 +66,9 @@
++++ coreutils-8.32-patched-nc/src/mv.c	2022-02-14 21:14:14.175156795 +0100
+@@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
    {"verbose", no_argument, NULL, 'v'},
-+  /* BEGIN progress mod */
 +  {"progress-bar", no_argument, NULL, 'g'},
-+  /* END progress mod */
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -170,8 +173,130 @@
+@@ -170,8 +171,130 @@
  {
    bool copy_into_self;
    bool rename_succeeded;
@@ -872,37 +816,30 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +431,11 @@
+@@ -306,6 +429,7 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
-+"), stdout); /* BEGIN progress mod - remove the complete line!*/
-+fputs (_("\
 +  -g, --progress-bar           add progress-bar\n\
-+"), stdout);
-+/* END progress mod - remove the complete line!*/ fputs (_("\
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +491,8 @@
+@@ -361,7 +485,7 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
 -  while ((c = getopt_long (argc, argv, "bfint:uvS:TZ", long_options, NULL))
-+  /* BEGIN and END progress mod - remove the g in the next line!*/
 +  while ((c = getopt_long (argc, argv, "bfint:uvgS:TZ", long_options, NULL))
           != -1)
      {
        switch (c)
-@@ -407,6 +538,11 @@
+@@ -407,6 +531,9 @@
          case 'v':
            x.verbose = true;
            break;
-+        /* BEGIN progress mod */
 +        case 'g':
 +          progress = true;
 +          break;
-+        /* END progress mod */
          case 'S':
            make_backups = true;
            backup_suffix = optarg;

--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.c	2021-12-24 20:12:31.563582368 +0100
++++ coreutils-8.32-patched/src/copy.c	2021-12-25 11:18:23.578451391 +0100
 @@ -129,6 +129,95 @@
    dev_t dev;
  };
@@ -17,7 +17,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +char * escape_double_quotes ( char * _cUnescapedString )
 +{
 +  char * _cEscapedString;
-+  _cEscapedString = (char *) malloc( sizeof(char) * strlen(_cUnescapedString) * 2 );
++  _cEscapedString = (char *) calloc( sizeof(char) * strlen(_cUnescapedString) * 2, sizeof(char) );
 +  size_t ipos = 0;
 +  size_t rpos = 0;
 +  for(rpos = 0, ipos = 0; _cUnescapedString[rpos] != '\0'; rpos++, ipos++)
@@ -443,7 +443,7 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
  #endif
 diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 --- coreutils-8.32/src/cp.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/cp.c	2021-12-23 19:29:20.521195377 +0100
++++ coreutils-8.32-patched/src/cp.c	2021-12-25 11:20:32.070133977 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -468,17 +468,26 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -635,6 +645,73 @@
+@@ -635,6 +645,83 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
 +    /* BEGIN progress mod */
 +    struct timeval start_time;
 +    if (progress) {
-+        g_iTotalSize = 0;
-+        g_iTotalFiles = 0;
-+        g_iFilesCopied = 0;
-+        g_iTotalWritten = 0;
++        if (g_iTotalSize == 0)
++          g_iTotalSize = 0;
++        if (g_iTotalFiles == 0)
++          g_iTotalFiles = n_files;
++        if (g_iFilesCopied == 0)
++          g_iFilesCopied = 0;
++        if (g_iDirectoriesCopied == 0)
++          g_iDirectoriesCopied = 0;
++        if (g_iTotalWritten == 0)
++          g_iTotalWritten = 0;
++
++        if (target_directory_operand (file[0], &sb, &new_dst, forcing))
++          g_iDirectoriesCopied++;
 +
 +        /* save time */
 +        gettimeofday ( & start_time, NULL );
@@ -503,7 +512,8 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +        if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
 +            printf("failed to run find\r");
 +        else
-+            g_iTotalFiles = atoi( output );
++            if ( atoi(output) > n_files )
++              g_iTotalFiles = atoi( output );
 +
 +        for (j = 0; j < iFiles; j++)
 +        {
@@ -535,14 +545,14 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +          /* close */
 +          pclose(fp);
 +        }
-+        g_iTotalSize = iTotalSize;
++        g_iTotalSize += iTotalSize;
 +    }
 +    /* END progress mod */
 +
  
    if (target_directory)
      {
-@@ -777,6 +854,46 @@
+@@ -777,6 +864,53 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -581,15 +591,22 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +        file_size_format ( s_copy_speed, copy_speed, 1 );
 +
 +        /* good-bye message */
-+        printf ( "%d files (%s) copied in %.1f seconds (%s/s).\n", g_iFilesCopied, sTotalWritten,
-+                 sec_elapsed, s_copy_speed );
++        char sFType[20];
++        if ( g_iDirectoriesCopied > 0 && g_iDirectoriesCopied == g_iFilesCopied )
++          sprintf ( sFType, "%s", "folder(s)" );
++        else if ( g_iDirectoriesCopied > 0 && g_iDirectoriesCopied < g_iFilesCopied )
++          sprintf ( sFType, "%s", "folder(s)/file(s)" );
++        else
++          sprintf ( sFType, "%s", "file(s)" );
++        printf ( "%d %s (%s) copied in %.1f seconds (%s/s).\n", g_iFilesCopied, sFType,
++                 sTotalWritten, sec_elapsed, s_copy_speed );
 +    }
 +    /* END progress mod */
 +
    return ok;
  }
  
-@@ -812,6 +929,7 @@
+@@ -812,6 +946,7 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
@@ -597,7 +614,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
    x->set_mode = false;
    x->mode = 0;
  
-@@ -950,7 +1068,8 @@
+@@ -950,7 +1085,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -607,7 +624,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1007,6 +1126,12 @@
+@@ -1007,6 +1143,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  

--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,10 +1,11 @@
 diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.c	2021-08-11 19:48:19.008225844 +0200
-@@ -129,6 +129,72 @@
++++ coreutils-8.32-patched/src/copy.c	2021-12-23 19:26:40.665650895 +0100
+@@ -129,6 +129,101 @@
    dev_t dev;
  };
  
++/* BEGIN progress mod */
 +struct progress_status {
 +  int iCountDown;
 +  char ** cProgressField;
@@ -13,7 +14,37 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +  struct stat src_open_sb;
 +};
 +
-+/* Begin progress Mod*/
++char * escape_double_quotes ( char * _cUnescapedString )
++{
++  int pos = 0;
++  int count = 0;
++  for(pos = 0; _cUnescapedString[pos] != '\0'; pos++)
++  {
++    if(_cUnescapedString[pos] == '"')
++      ++count;
++  }
++
++  char * _cEscapedString;
++  _cEscapedString = calloc( sizeof(char) * ( pos + 1 + count * 2 ), sizeof(char) );
++
++  int epos = 0;
++  for(pos = 0; _cUnescapedString[pos] != '\0'; pos++)
++  {
++    if(_cUnescapedString[pos] == '"')
++    {
++      _cEscapedString[epos] = '\\';
++      epos++;
++      _cEscapedString[epos] = _cUnescapedString[pos];
++    }
++    else
++      _cEscapedString[epos] = _cUnescapedString[pos];
++    epos++;
++  }
++  epos++;
++  _cEscapedString[epos] = '\0';
++  return _cEscapedString;
++}
++
 +static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
 +{
 +    double dPercent = (double) _lProgress / (double) _lTotal * 100.f;
@@ -69,32 +100,34 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +}
 +/* END progress mod */
 +
-+
-+
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -258,10 +324,11 @@
-    bytes read.  */
+@@ -259,9 +354,16 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
--             size_t hole_size, bool punch_holes,
-+             size_t hole_size, bool punch_holes, bool move_mode,
+              size_t hole_size, bool punch_holes,
++             /* BEGIN progress mod */
++             bool move_mode,
++             /* END progress mod */
               char const *src_name, char const *dst_name,
               uintmax_t max_n_read, off_t *total_n_read,
 -             bool *last_write_made_hole)
-+             bool *last_write_made_hole,
-+             struct progress_status *s_progress)
++             bool *last_write_made_hole
++             /* BEGIN progress mod */
++             , struct progress_status *s_progress
++             /* END progress mod */
++             )
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -270,6 +337,85 @@
+@@ -270,6 +372,85 @@
  
    while (max_n_read)
      {
 +
++    /* BEGIN progress mod */
 +    if (progress) {
-+          /* BEGIN progress mod */
 +          /* update countdown */
 +          s_progress->iCountDown--;
 +          char * sProgressBar = s_progress->cProgressField[5];
@@ -130,8 +163,8 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +            /* print out */
 +            sprintf ( s_progress->cProgressField[3],
 +              move_mode
-+                ? "Moving at %s/s (about %uh %um %us remaining)"
-+                : "Copying at %s/s (about %uh %um %us remaining)", s_copy_speed,
++                ? "moving at %s/s (about %uh %um %us remaining)"
++                : "copying at %s/s (about %uh %um %us remaining)", s_copy_speed,
 +              hours_remaining, min_remaining, sec_remaining );
 +
 +            int fs_len;
@@ -168,13 +201,13 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +              printf ( "\r\033[3A" );
 +            fflush ( stdout );
 +          }
-+          /* END progress mod */
 +      }
++      /* END progress mod */
 +
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -354,6 +500,14 @@
+@@ -354,6 +535,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -189,7 +222,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -420,9 +574,11 @@
+@@ -420,9 +609,11 @@
  static bool
  extent_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, off_t src_total_size,
@@ -203,26 +236,36 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  {
    struct extent_scan scan;
    off_t last_ext_start = 0;
-@@ -553,10 +709,16 @@
+@@ -553,10 +744,26 @@
                last_ext_len = ext_len;
                bool read_hole;
  
++              /* BEGIN progress mod */
 +              struct timeval a;
 +              struct stat b;
 +
 +              struct progress_status s_progress={iCountDown, cProgressField, last_time, last_size, iBarLength, src_open_sb};
++              /* END progress mod */
 +
 +
                if ( ! sparse_copy (src_fd, dest_fd, buf, buf_size,
                                    sparse_mode == SPARSE_ALWAYS ? hole_size: 0,
 -                                  true, src_name, dst_name, ext_len, &n_read,
 -                                  &read_hole))
-+                                  true, move_mode, src_name, dst_name, ext_len,
-+                                  &n_read, &read_hole,&s_progress))
++                                  true,
++                                  /* BEGIN progress mod */
++                                  move_mode,
++                                  /* END progress mod */
++                                  src_name, dst_name, ext_len, &n_read,
++                                  &read_hole
++                                  /* BEGIN progress mod */
++                                  ,&s_progress
++                                  /* END progress mod */
++                                  ))
                  goto fail;
  
                dest_pos = ext_start + n_read;
-@@ -1305,6 +1467,71 @@
+@@ -1305,6 +1512,75 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -261,7 +304,11 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +        file_size_format ( cProgressField[1] + iBarLength - 9, g_iTotalSize, 1 );
 +
 +        /* show how many files were written */
-+        int sum_length = sprintf ( cProgressField[1], "%d files copied so far...", g_iFilesCopied );
++        int sum_length = 0;
++        if ( x->move_mode )
++          sum_length = sprintf ( cProgressField[1], "%d files moved so far...", g_iFilesCopied );
++        else
++          sum_length = sprintf ( cProgressField[1], "%d files copied so far...", g_iFilesCopied );
 +        cProgressField[1][sum_length] = ' ';
 +      }
 +
@@ -294,7 +341,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        if (sparse_src)
          {
            bool normal_copy_required;
-@@ -1316,7 +1543,9 @@
+@@ -1316,7 +1592,9 @@
            if (extent_copy (source_desc, dest_desc, buf, buf_size, hole_size,
                             src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
@@ -305,27 +352,38 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
              goto preserve_metadata;
  
            if (! normal_copy_required)
-@@ -1328,11 +1557,12 @@
+@@ -1328,11 +1606,23 @@
  
        off_t n_read;
        bool wrote_hole_at_eof;
++
++      /* BEGIN progress mod */
 +      struct progress_status s_progress = { iCountDown, cProgressField, last_time, last_size, iBarLength, src_open_sb};
++      /* END progress mod */
++
        if (! sparse_copy (source_desc, dest_desc, buf, buf_size,
                           make_holes ? hole_size : 0,
 -                         x->sparse_mode == SPARSE_ALWAYS, src_name, dst_name,
 -                         UINTMAX_MAX, &n_read,
 -                         &wrote_hole_at_eof))
-+                         x->sparse_mode == SPARSE_ALWAYS, x->move_mode,
++                         x->sparse_mode == SPARSE_ALWAYS,
++                         /* BEGIN progress mod */
++                         x->move_mode,
++                         /* END progress mod */
 +                         src_name, dst_name, UINTMAX_MAX, &n_read,
-+                         &wrote_hole_at_eof, &s_progress))
++                         &wrote_hole_at_eof
++                         /* BEGIN progress mod */
++                         , &s_progress
++                         /* END progress mod */
++                         ))
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1343,6 +1573,14 @@
+@@ -1343,6 +1633,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
-+       /* BEGIN progress mod */
++      /* BEGIN progress mod */
 +      if (progress) {
 +            int i;
 +            for ( i = 0; i < 6; i++ )
@@ -336,7 +394,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
      }
  
  preserve_metadata:
-@@ -1716,15 +1954,15 @@
+@@ -1716,15 +2014,15 @@
        fprintf (stderr,
                 (x->move_mode || x->unlink_dest_before_opening
                  || x->unlink_dest_after_failed_open)
@@ -357,59 +415,72 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  
 diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
 --- coreutils-8.32/src/copy.h	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.h	2021-08-11 19:40:37.729820358 +0200
-@@ -234,6 +234,9 @@
++++ coreutils-8.32-patched/src/copy.h	2021-12-23 12:24:33.256775516 +0100
+@@ -234,6 +234,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
  
++  /* BEGIN progress mod */
 +  /* If true, draw a nice progress bar on screen */
 +  bool progress_bar;
++  /* END progress mod */
 +
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -304,4 +307,15 @@
+@@ -304,4 +309,18 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
-+/* BEGIN OF PROGRESS MOD */
++/* BEGIN progress mod */
++char * escape_double_quotes ( char * _cUnescapedString );
++
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
 +__attribute__((__common__)) long g_iTotalSize;
 +__attribute__((__common__)) long g_iTotalWritten;
 +__attribute__((__common__)) int g_iFilesCopied;
++__attribute__((__common__)) int g_iDirectoriesCopied;
 +__attribute__((__common__)) struct timeval g_oStartTime;
 +__attribute__((__common__)) int g_iTotalFiles;
 +__attribute__((__common__)) bool progress;
-+/* END OF PROGRESS MOD */
++/* END progress mod */
 +
  #endif
 diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 --- coreutils-8.32/src/cp.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/cp.c	2021-08-11 19:40:37.729820358 +0200
-@@ -131,6 +131,7 @@
++++ coreutils-8.32-patched/src/cp.c	2021-12-23 19:29:20.521195377 +0100
+@@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
++  /* BEGIN progress mod */
 +  {"progress-bar", no_argument, NULL, 'g'},
++  /* END progress mod */
    {"verbose", no_argument, NULL, 'v'},
    {GETOPT_SELINUX_CONTEXT_OPTION_DECL},
    {GETOPT_HELP_OPTION_DECL},
-@@ -170,6 +171,7 @@
+@@ -170,6 +173,13 @@
    -f, --force                  if an existing destination file cannot be\n\
                                   opened, remove it and try again (this option\n\
                                   is ignored when the -n option is also used)\n\
-+  -g, --progress-bar           add a progress bar\n\
++"), stdout); /* BEGIN progress mod - remove the complete line!*/
++      fputs (_("\
++  -g, --progress-bar           add a progress bar.\n\
++                                 Note that this doesn't work with reflink,\n\
++                                 reflink will be automatically disabled\n\
++"), stdout);
++/* END progress mod - remove the complete line!*/ fputs (_("\
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -635,6 +637,70 @@
+@@ -635,6 +645,73 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
++    /* BEGIN progress mod */
 +    struct timeval start_time;
 +    if (progress) {
-+        /* BEGIN progress mod */
 +        g_iTotalSize = 0;
 +        g_iTotalFiles = 0;
 +        g_iFilesCopied = 0;
@@ -419,7 +490,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +        gettimeofday ( & start_time, NULL );
 +        g_oStartTime = start_time;
 +
-+        printf ( "Calculating total size... \r" );
++        printf ( "calculating total size... \r" );
 +        fflush ( stdout );
 +        long iTotalSize = 0;
 +        int iFiles = n_files;
@@ -429,22 +500,25 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +
 +        /* how many files are we copying */
 +        char command[1024];
-+        sprintf( command, "find \"%s\" -type f | wc -l", file[0]);
++        char * _cEscapedString = escape_double_quotes( file[0] );
++        sprintf( command, "find \"%s\" -type f | wc -l", _cEscapedString );
++        free( _cEscapedString );
 +        FILE *fp ;
 +        char output[1024];
 +        fp = popen(command,"r");
 +        if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
-+            printf("failed to run find.\n");
++            printf("failed to run find\r");
 +        else
-+            g_iTotalFiles = atoi( output ) ;
++            g_iTotalFiles = atoi( output );
 +
 +        for (j = 0; j < iFiles; j++)
 +        {
 +          /* call du -s for each file */
 +          /* create command */
 +          char command[1024];
-+          sprintf ( command, "du -s \"%s\"", file[j] );
-+          /* TODO: replace all quote signs in file[i] */
++          char * _cEscapedString = escape_double_quotes( file[j] );
++          sprintf ( command, "du -s \"%s\"", _cEscapedString );
++          free( _cEscapedString );
 +
 +          FILE *fp;
 +          char output[1024];
@@ -452,7 +526,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +          /* run command */
 +          fp = popen(command, "r");
 +          if (fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL) {
-+            printf("failed to run du.\n" );
++            printf("failed to run du\r" );
 +          }
 +          else
 +          {
@@ -460,7 +534,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +            strchr ( output, '\t' )[0] = '\0';
 +            iTotalSize += atol ( output );
 +
-+            printf ( "Calculating total size... %ld\r", iTotalSize );
++            printf ( "calculating total size... %ld\r", iTotalSize );
 +            fflush ( stdout );
 +          }
 +
@@ -468,18 +542,18 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +          pclose(fp);
 +        }
 +        g_iTotalSize = iTotalSize;
-+        /* END progress mod */
 +    }
++    /* END progress mod */
 +
  
    if (target_directory)
      {
-@@ -777,6 +843,46 @@
+@@ -777,6 +854,46 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
++    /* BEGIN progress mod */
 +    if (progress) {
-+        /* BEGIN progress mod */
 +        /* remove everything */
 +        int i;
 +        if ( g_iTotalFiles > 1 )
@@ -515,13 +589,13 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +        /* good-bye message */
 +        printf ( "%d files (%s) copied in %.1f seconds (%s/s).\n", g_iFilesCopied, sTotalWritten,
 +                 sec_elapsed, s_copy_speed );
-+        /* END progress mod */
 +    }
++    /* END progress mod */
 +
    return ok;
  }
  
-@@ -812,6 +918,7 @@
+@@ -812,6 +929,7 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
@@ -529,97 +603,124 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
    x->set_mode = false;
    x->mode = 0;
  
-@@ -950,7 +1057,7 @@
+@@ -950,7 +1068,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
 -  while ((c = getopt_long (argc, argv, "abdfHilLnprst:uvxPRS:TZ",
++  /* BEGIN and END progress mod - remove the g in the next line!*/
 +  while ((c = getopt_long (argc, argv, "abdfgHilLnprst:uvxPRS:TZ",
                             long_opts, NULL))
           != -1)
      {
-@@ -1007,6 +1114,10 @@
+@@ -1007,6 +1126,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
++        /* BEGIN progress mod */
 +        case 'g':
 +          progress = true;
 +          break;
++        /* END progress mod */
 +
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
 diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 --- coreutils-8.32/src/mv.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/mv.c	2021-08-11 19:40:37.729820358 +0200
-@@ -66,6 +66,7 @@
++++ coreutils-8.32-patched/src/mv.c	2021-12-23 19:31:05.335749444 +0100
+@@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
    {"verbose", no_argument, NULL, 'v'},
-+  {"progress-ar", no_argument, NULL, 'g'},
++  /* BEGIN progress mod */
++  {"progress-bar", no_argument, NULL, 'g'},
++  /* END progress mod */
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -168,10 +169,86 @@
- static bool
- do_move (const char *source, const char *dest, const struct cp_options *x)
+@@ -170,8 +173,121 @@
  {
-+  struct timeval start_time;
-+
    bool copy_into_self;
    bool rename_succeeded;
++
++  /* BEGIN progress mod */
++  struct timeval start_time;
++
 +  if(progress && x->rename_errno != 0) {
-+    /* BEGIN progress mod */
-+    g_iTotalSize = 0;
-+    g_iFilesCopied = 0;
-+    g_iTotalWritten = 0;
++    if (g_iTotalSize == 0)
++      g_iTotalSize = 0;
++    if (g_iTotalFiles == 0)
++      g_iTotalFiles = 0;
++    if (g_iFilesCopied == 0)
++      g_iFilesCopied = 0;
++    if (g_iDirectoriesCopied == 0)
++      g_iDirectoriesCopied = 0;
++    if (g_iTotalWritten == 0)
++      g_iTotalWritten = 0;
++
++    if (target_directory_operand (source))
++      g_iDirectoriesCopied++;
 +
 +    gettimeofday (& start_time, NULL);
 +    g_oStartTime = start_time;
 +
-+    printf ("Calculating total size... \r");
++    /* how many files are we copying */
++    char command[1024];
++    char output[1024];
++    FILE *fp ;
++
++    char * _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
++    sprintf( command, "find \"%s\" -type f | wc -l", _cEscapedString );
++    free( _cEscapedString );
++    fp = popen(command,"r");
++    if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
++      printf("failed to run find\r");
++    else
++      g_iTotalFiles = atoi( output );
++
++    printf ("calculating total size... \r");
 +    fflush (stdout);
 +    long iTotalSize = 0;
 +    /* call du -s for each file */
 +    /* create command */
-+    char command[1024];
-+    sprintf ( command, "du -s '%s'", source );
-+    /* TODO: replace all quote signs in file[i] */
-+
-+    FILE *fp;
-+    char output[1024];
++    _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
++    sprintf ( command, "du -s \"%s\"", _cEscapedString );
++    free( _cEscapedString );
 +
 +    /* run command */
 +    fp = popen(command, "r");
 +    if (fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL) {
-+      //printf("failed to run du.\n" );
++      printf("failed to run du\r" );
 +    }
 +    else
 +    {
 +      /* isolate size */
 +      strchr ( output, '\t' )[0] = '\0';
 +      iTotalSize += atol ( output );
-+      printf ( "Calculating total size... %ld\r", iTotalSize );
++      printf ( "calculating total size... %ld\r", iTotalSize );
 +      fflush ( stdout );
 +    }
 +
 +    /* close */
 +    pclose(fp);
-+    g_iTotalSize = iTotalSize;
-+    /* END progress mod */
-+
++    g_iTotalSize += iTotalSize;
 +  }
++  /* END progress mod */
 +
    bool ok = copy (source, dest, false, x, &copy_into_self, &rename_succeeded);
  
++  /* BEGIN progress mod */
 +  if (progress && (x->rename_errno != 0 && ok)) {
-+    /* BEGIN progress mod */
 +    /* remove everything */
 +    int i;
 +    int limit = (g_iTotalFiles > 1 ? 6 : 3);
-+    for ( i = 0; i < limit; i++ )
-+      printf ( "\033[K\n" );
-+    printf ( "\r\033[3A" );
++    if (!rename_succeeded)
++    {
++      for ( i = 0; i < limit; i++ )
++        printf ( "\033[K\n" );
++      printf ( "\r\033[3A" );
++    }
 +
 +    /* save time */
 +    struct timeval end_time;
@@ -638,41 +739,59 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 +    char s_copy_speed[20];
 +    file_size_format ( s_copy_speed, copy_speed, 1 );
 +
++    /* increase counter */
++    g_iFilesCopied++;
++
 +    /* good-bye message */
-+    printf ( "%d files (%s) moved in %.1f seconds (%s/s).\n", g_iFilesCopied, sTotalWritten,
-+             sec_elapsed, s_copy_speed );
-+    /* END progress mod */
++    if ( x->last_file )
++    {
++      char sFType[20];
++      if ( g_iDirectoriesCopied > 0 && g_iDirectoriesCopied == g_iFilesCopied )
++        sprintf ( sFType, "%s", "folder(s)" );
++      else if ( g_iDirectoriesCopied > 0 && g_iDirectoriesCopied < g_iFilesCopied )
++        sprintf ( sFType, "%s", "folder(s)/file(s)" );
++      else
++        sprintf ( sFType, "%s", "file(s)" );
++      printf ( "%d %s (%s) moved in %.1f seconds (%s/s).\n", g_iFilesCopied, sFType,
++               sTotalWritten, sec_elapsed, s_copy_speed );
++    }
 +  }
++  /* END progress mod */
 +
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +383,7 @@
+@@ -306,6 +422,11 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
++"), stdout); /* BEGIN progress mod - remove the complete line!*/
++fputs (_("\
 +  -g, --progress-bar           add progress-bar\n\
++"), stdout);
++/* END progress mod - remove the complete line!*/ fputs (_("\
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +439,7 @@
+@@ -361,7 +482,8 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
 -  while ((c = getopt_long (argc, argv, "bfint:uvS:TZ", long_options, NULL))
++  /* BEGIN and END progress mod - remove the g in the next line!*/
 +  while ((c = getopt_long (argc, argv, "bfint:uvgS:TZ", long_options, NULL))
           != -1)
      {
        switch (c)
-@@ -407,6 +485,11 @@
+@@ -407,6 +529,11 @@
          case 'v':
            x.verbose = true;
            break;
-+
++        /* BEGIN progress mod */
 +        case 'g':
 +          progress = true;
 +          break;
-+
++        /* END progress mod */
          case 'S':
            make_backups = true;
            backup_suffix = optarg;

--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.c	2022-02-13 16:14:31.534047672 +0100
++++ coreutils-8.32-patched/src/copy.c	2022-02-14 21:10:42.216002503 +0100
 @@ -129,6 +129,133 @@
    dev_t dev;
  };
@@ -488,7 +488,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  
 diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
 --- coreutils-8.32/src/copy.h	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.h	2022-02-13 16:14:31.538047737 +0100
++++ coreutils-8.32-patched/src/copy.h	2022-02-14 21:10:42.220002638 +0100
 @@ -234,6 +234,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -526,7 +526,7 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
  #endif
 diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 --- coreutils-8.32/src/cp.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/cp.c	2022-02-13 16:14:31.538047737 +0100
++++ coreutils-8.32-patched/src/cp.c	2022-02-14 21:10:42.220002638 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -588,7 +588,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +        FILE *fp ;
 +        char output[1024];
 +        char fcmd[] = "find";
-+        fp = spawn(fcmd, (char *[]){ fcmd, file[0], NULL, "-type", "f", NULL });
++        fp = spawn(fcmd, (char *[]){ fcmd, file[0], "-type", "f", NULL });
 +        if ( fp == NULL)
 +            printf("failed to run find\r");
 +        else
@@ -730,7 +730,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
            break;
 diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 --- coreutils-8.32/src/mv.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/mv.c	2022-02-13 16:14:31.542047802 +0100
++++ coreutils-8.32-patched/src/mv.c	2022-02-14 21:10:42.220002638 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -771,7 +771,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 +    FILE *fp ;
 +    char output[1024];
 +    char fcmd[] = "find";
-+    fp = spawn(fcmd, (char *[]){ fcmd, (unsigned char *)(size_t)source, NULL, "-type", "f", NULL });
++    fp = spawn(fcmd, (char *[]){ fcmd, (char *)source, "-type", "f", NULL });
 +    if ( fp == NULL)
 +      printf("failed to run find\r");
 +    else

--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.c	2022-01-04 21:56:14.545035647 +0100
-@@ -129,6 +129,119 @@
++++ coreutils-8.32-patched/src/copy.c	2022-01-12 20:08:19.573923682 +0100
+@@ -129,6 +129,121 @@
    dev_t dev;
  };
  
@@ -39,28 +39,30 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +  return _cEscapedString;
 +}
 +
-+char * format_elapsed_time ( double sec_elapsed )
++void format_time ( char * _cDest, double seconds, bool showall )
 +{
 +  // hours
-+  long hr = ( (int) sec_elapsed / (60 * 60)) % 24;
++  int hr = ( (int) seconds / (60 * 60)) % 24;
 +  // minutes
-+  int min = ( (int) sec_elapsed / 60) % 60;
++  int min = ( (int) seconds / 60) % 60;
 +  // seconds
-+  double sec = sec_elapsed - (hr * (60 * 60)) - (min * 60);
-+  size_t maxneeded = snprintf(NULL, 0, "%ldh %dm %.1fs", hr, min, sec) + 1;
-+  char * _cElapsedTimeString;
-+  _cElapsedTimeString = (char *) calloc( sizeof(char) * maxneeded, sizeof(char) );
-+  if ( sec_elapsed >= 3600 )
++  double sec = seconds - (hr * (60 * 60)) - (min * 60);
++  if ( showall )
 +  {
-+    sprintf(_cElapsedTimeString, "%ldh %dm %.1fs", hr, min, sec);
-+  } else if ( sec_elapsed >= 60 )
++    if ( seconds < 0 )
++      sprintf(_cDest, "%2ch %2cm %2cs", '0', '0', '?');
++    else
++      sprintf(_cDest, "%2dh %2dm %2ds", hr, min, (int) sec);
++  } else  if ( seconds >= 3600 )
 +  {
-+    sprintf(_cElapsedTimeString, "%dm %.1fs", min, sec);
++    sprintf(_cDest, "%2dh %2dm %4.1fs", hr, min, sec);
++  } else if ( seconds >= 60 )
++  {
++    sprintf(_cDest, "%2dm %4.1fs", min, sec);
 +  } else
 +  {
-+    sprintf(_cElapsedTimeString, "%.1fs", sec);
++    sprintf(_cDest, "%4.1fs", sec);
 +  }
-+  return _cElapsedTimeString;
 +}
 +
 +static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
@@ -121,7 +123,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -259,9 +372,16 @@
+@@ -259,17 +374,129 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes,
@@ -139,8 +141,17 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -270,6 +390,85 @@
+   bool make_hole = false;
+   off_t psize = 0;
  
++ /* BEGIN progress mod */
++  gettimeofday ( & g_oFStartTime, NULL );
++  g_iFTotalWritten = 0;
++  struct stat st;
++  stat(src_name, &st);
++  g_iFTotalSize = st.st_size/1024;
++  /* END progress mod */
++
    while (max_n_read)
      {
 +
@@ -159,6 +170,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +            struct timeval cur_time;
 +            gettimeofday ( & cur_time, NULL );
 +            int cur_size = g_iTotalWritten + *total_n_read / 1024;
++            int cur_fsize = g_iFTotalWritten + *total_n_read / 1024;
 +            int usec_elapsed = cur_time.tv_usec - s_progress->last_time.tv_usec;
 +            double sec_elapsed = ( double ) usec_elapsed / 1000000.f;
 +            sec_elapsed += ( double ) ( cur_time.tv_sec - s_progress->last_time.tv_sec );
@@ -172,18 +184,35 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +
 +            /* how many time has passed since the start? */
 +            int isec_elapsed = cur_time.tv_sec - g_oStartTime.tv_sec;
++            int isec_felapsed = cur_time.tv_sec - g_oFStartTime.tv_sec;
 +            int sec_remaining = ( int ) ( ( double ) isec_elapsed / cur_size
 +              * g_iTotalSize ) - isec_elapsed;
-+            int min_remaining = sec_remaining / 60;
-+            sec_remaining -= min_remaining * 60;
-+            int hours_remaining = min_remaining / 60;
-+            min_remaining -= hours_remaining * 60;
++            int sec_fremaining = ( int ) ( ( double ) isec_felapsed / cur_fsize
++              * g_iFTotalSize ) - isec_felapsed;
 +            /* print out */
++
++            char f_ttime[20];
++            char f_ftime[20];
++            format_time(f_ttime, sec_remaining, true);
++            format_time(f_ftime, sec_fremaining, true);
++
++            sprintf ( s_progress->cProgressField[1],
++              move_mode
++                ? "%d of %d files moved (about %s remaining) "
++                : "%d of %d files copied (about %s remaining) ",
++                g_iFilesCopied, g_iTotalFiles, f_ttime );
++
++            char s_ftime[40] = "";
++
++            if (g_iTotalFiles > 1)
++              sprintf ( s_ftime, "(about %s remaining)", f_ftime );
++            else
++              sprintf ( s_ftime, "(about %s remaining)", f_ttime );
++
 +            sprintf ( s_progress->cProgressField[3],
 +              move_mode
-+                ? "moving at %s/s (about %uh %um %us remaining)"
-+                : "copying at %s/s (about %uh %um %us remaining)", s_copy_speed,
-+              hours_remaining, min_remaining, sec_remaining );
++                ? "moving at %s/s %s"
++                : "copying at %s/s %s", s_copy_speed, s_ftime );
 +
 +            int fs_len;
 +            if ( g_iTotalFiles > 1 )
@@ -225,7 +254,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -354,6 +553,14 @@
+@@ -354,6 +581,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -240,7 +269,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -421,8 +628,16 @@
+@@ -421,8 +656,16 @@
  extent_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, off_t src_total_size,
               enum Sparse_type sparse_mode,
@@ -258,7 +287,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  {
    struct extent_scan scan;
    off_t last_ext_start = 0;
-@@ -553,10 +768,26 @@
+@@ -553,10 +796,26 @@
                last_ext_len = ext_len;
                bool read_hole;
  
@@ -287,7 +316,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
                  goto fail;
  
                dest_pos = ext_start + n_read;
-@@ -1305,6 +1536,75 @@
+@@ -1305,6 +1564,75 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -327,10 +356,10 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +
 +        /* show how many files were written */
 +        int sum_length = 0;
-+        if ( x->move_mode )
-+          sum_length = sprintf ( cProgressField[1], "%d files moved so far...", g_iFilesCopied );
-+        else
-+          sum_length = sprintf ( cProgressField[1], "%d files copied so far...", g_iFilesCopied );
++        sum_length = sprintf ( cProgressField[1],
++          x->move_mode
++            ? "%d of %d files moved so far"
++            : "%d of %d files copied so far", g_iFilesCopied, g_iTotalFiles );
 +        cProgressField[1][sum_length] = ' ';
 +      }
 +
@@ -363,7 +392,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        if (sparse_src)
          {
            bool normal_copy_required;
-@@ -1316,7 +1616,15 @@
+@@ -1316,7 +1644,15 @@
            if (extent_copy (source_desc, dest_desc, buf, buf_size, hole_size,
                             src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
@@ -380,7 +409,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
              goto preserve_metadata;
  
            if (! normal_copy_required)
-@@ -1328,11 +1636,24 @@
+@@ -1328,11 +1664,24 @@
  
        off_t n_read;
        bool wrote_hole_at_eof;
@@ -407,7 +436,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1343,6 +1664,14 @@
+@@ -1343,6 +1692,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -422,7 +451,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
      }
  
  preserve_metadata:
-@@ -1716,15 +2045,19 @@
+@@ -1716,15 +2073,19 @@
        fprintf (stderr,
                 (x->move_mode || x->unlink_dest_before_opening
                  || x->unlink_dest_after_failed_open)
@@ -447,7 +476,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  
 diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
 --- coreutils-8.32/src/copy.h	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.h	2022-01-04 21:56:14.545035647 +0100
++++ coreutils-8.32-patched/src/copy.h	2022-01-12 20:08:19.577923660 +0100
 @@ -234,6 +234,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -460,21 +489,24 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -304,4 +309,19 @@
+@@ -304,4 +309,22 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
 +/* BEGIN progress mod */
 +char * escape_double_quotes ( char * _cUnescapedString );
-+char * format_elapsed_time ( double sec_elapsed );
++void format_time ( char * _cDst, double seconds, bool showall );
 +
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
 +__attribute__((__common__)) long g_iTotalSize;
++__attribute__((__common__)) long g_iFTotalSize;
 +__attribute__((__common__)) long g_iTotalWritten;
++__attribute__((__common__)) long g_iFTotalWritten;
 +__attribute__((__common__)) int g_iFilesCopied;
 +__attribute__((__common__)) int g_iDirectoriesCopied;
 +__attribute__((__common__)) struct timeval g_oStartTime;
++__attribute__((__common__)) struct timeval g_oFStartTime;
 +__attribute__((__common__)) int g_iTotalFiles;
 +__attribute__((__common__)) bool progress;
 +/* END progress mod */
@@ -482,7 +514,7 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
  #endif
 diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 --- coreutils-8.32/src/cp.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/cp.c	2022-01-04 21:56:14.545035647 +0100
++++ coreutils-8.32-patched/src/cp.c	2022-01-12 20:08:19.577923660 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -591,7 +623,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
  
    if (target_directory)
      {
-@@ -777,6 +864,53 @@
+@@ -777,6 +864,56 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -637,25 +669,30 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +          sprintf ( sFType, "%s", "folder(s)/file(s)" );
 +        else
 +          sprintf ( sFType, "%s", "file(s)" );
++
++        char f_time[20];
++        format_time(f_time, sec_elapsed, true);
 +        printf ( "%d %s (%s) copied in %s (%s/s).\n", g_iFilesCopied, sFType,
-+                 sTotalWritten, format_elapsed_time(sec_elapsed), s_copy_speed );
++                 sTotalWritten, f_time, s_copy_speed );
 +    }
 +    /* END progress mod */
 +
    return ok;
  }
  
-@@ -812,6 +946,9 @@
+@@ -812,6 +949,11 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
++
 +  /* BEGIN progress mod */
 +  x->progress_bar = false;
 +  /* END progress mod */
++
    x->set_mode = false;
    x->mode = 0;
  
-@@ -950,7 +1087,8 @@
+@@ -950,7 +1092,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -665,7 +702,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1007,6 +1145,12 @@
+@@ -1007,6 +1150,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
@@ -680,7 +717,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
            break;
 diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 --- coreutils-8.32/src/mv.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/mv.c	2022-01-04 21:56:14.549035719 +0100
++++ coreutils-8.32-patched/src/mv.c	2022-01-12 20:08:19.577923660 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -691,7 +728,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -170,8 +173,121 @@
+@@ -170,8 +173,124 @@
  {
    bool copy_into_self;
    bool rename_succeeded;
@@ -804,8 +841,11 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 +        sprintf ( sFType, "%s", "folder(s)/file(s)" );
 +      else
 +        sprintf ( sFType, "%s", "file(s)" );
++
++      char f_time[20];
++      format_time(f_time, sec_elapsed, true);
 +      printf ( "%d %s (%s) moved in %s (%s/s).\n", g_iFilesCopied, sFType,
-+               sTotalWritten, format_elapsed_time(sec_elapsed), s_copy_speed );
++               sTotalWritten, f_time, s_copy_speed );
 +    }
 +  }
 +  /* END progress mod */
@@ -813,7 +853,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +422,11 @@
+@@ -306,6 +425,11 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
@@ -825,7 +865,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +482,8 @@
+@@ -361,7 +485,8 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
@@ -835,7 +875,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
           != -1)
      {
        switch (c)
-@@ -407,6 +529,11 @@
+@@ -407,6 +532,11 @@
          case 'v':
            x.verbose = true;
            break;

--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.c	2022-01-12 20:08:19.573923682 +0100
-@@ -129,6 +129,121 @@
++++ coreutils-8.32-patched/src/copy.c	2022-02-13 16:14:31.534047672 +0100
+@@ -129,6 +129,133 @@
    dev_t dev;
  };
  
@@ -14,29 +14,41 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +  struct stat src_open_sb;
 +};
 +
-+char * escape_double_quotes ( char * _cUnescapedString )
++FILE * spawn( const char *cmd, char *const argv[] )
 +{
-+  char * _cEscapedString;
-+  _cEscapedString = (char *) calloc( sizeof(char) * strlen(_cUnescapedString) * 2, sizeof(char) );
-+  size_t ipos = 0;
-+  size_t rpos = 0;
-+  for(rpos = 0, ipos = 0; _cUnescapedString[rpos] != '\0'; rpos++, ipos++)
-+  {
-+    if(_cUnescapedString[rpos] == '"')
-+    {
-+      _cEscapedString[ipos] = '\\';
-+      ipos++;
++    FILE *ret = NULL;
++    int pfd_read[2];
++    pid_t pid;
++
++    if (cmd == NULL || argv == NULL)
++        return ret;
++
++    if (pipe(pfd_read) < 0) {
++        error(0, errno, "pipe: %s", cmd);
++        return ret;
 +    }
-+    if(_cUnescapedString[rpos] == '`')
-+    {
-+      _cEscapedString[ipos] = '\\';
-+      ipos++;
++
++    if ((pid = fork()) == 0) {
++        int err = dup2(pfd_read[1], 1) < 0;
++        close(pfd_read[0]);
++        close(pfd_read[1]);
++
++        if (err)
++            error(EXIT_FAILURE, errno, "dup2: %s", cmd);
++        execvp(cmd, argv);
++        error(EXIT_FAILURE, errno, "exec: %s", cmd);
 +    }
-+    _cEscapedString[ipos] = _cUnescapedString[rpos];
-+  }
-+  ipos++;
-+  _cEscapedString[ipos] = '\0';
-+  return _cEscapedString;
++
++    close(pfd_read[1]);
++
++    if (pid < 0) {
++        close(pfd_read[0]);
++        error(0, errno, "fork: %s", cmd);
++        return ret;
++    }
++
++    ret = fdopen(pfd_read[0], "r");
++    return ret;
 +}
 +
 +void format_time ( char * _cDest, double seconds, bool showall )
@@ -123,7 +135,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -259,17 +374,129 @@
+@@ -259,17 +386,129 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes,
@@ -254,7 +266,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -354,6 +581,14 @@
+@@ -354,6 +593,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -269,7 +281,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -421,8 +656,16 @@
+@@ -421,8 +668,16 @@
  extent_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, off_t src_total_size,
               enum Sparse_type sparse_mode,
@@ -287,7 +299,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  {
    struct extent_scan scan;
    off_t last_ext_start = 0;
-@@ -553,10 +796,26 @@
+@@ -553,10 +808,26 @@
                last_ext_len = ext_len;
                bool read_hole;
  
@@ -316,7 +328,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
                  goto fail;
  
                dest_pos = ext_start + n_read;
-@@ -1305,6 +1564,75 @@
+@@ -1305,6 +1576,75 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -392,7 +404,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        if (sparse_src)
          {
            bool normal_copy_required;
-@@ -1316,7 +1644,15 @@
+@@ -1316,7 +1656,15 @@
            if (extent_copy (source_desc, dest_desc, buf, buf_size, hole_size,
                             src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
@@ -409,7 +421,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
              goto preserve_metadata;
  
            if (! normal_copy_required)
-@@ -1328,11 +1664,24 @@
+@@ -1328,11 +1676,24 @@
  
        off_t n_read;
        bool wrote_hole_at_eof;
@@ -436,7 +448,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1343,6 +1692,14 @@
+@@ -1343,6 +1704,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -451,7 +463,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
      }
  
  preserve_metadata:
-@@ -1716,15 +2073,19 @@
+@@ -1716,15 +2085,19 @@
        fprintf (stderr,
                 (x->move_mode || x->unlink_dest_before_opening
                  || x->unlink_dest_after_failed_open)
@@ -476,7 +488,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  
 diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
 --- coreutils-8.32/src/copy.h	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.h	2022-01-12 20:08:19.577923660 +0100
++++ coreutils-8.32-patched/src/copy.h	2022-02-13 16:14:31.538047737 +0100
 @@ -234,6 +234,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -494,7 +506,7 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
  mode_t cached_umask (void);
  
 +/* BEGIN progress mod */
-+char * escape_double_quotes ( char * _cUnescapedString );
++FILE * spawn( const char *cmd, char *const argv[] );
 +void format_time ( char * _cDst, double seconds, bool showall );
 +
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
@@ -514,7 +526,7 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
  #endif
 diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 --- coreutils-8.32/src/cp.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/cp.c	2022-01-12 20:08:19.577923660 +0100
++++ coreutils-8.32-patched/src/cp.c	2022-02-13 16:14:31.538047737 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -539,7 +551,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -635,6 +645,83 @@
+@@ -635,6 +645,84 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
@@ -573,33 +585,34 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +        int j;
 +
 +        /* how many files are we copying */
-+        char command[1024];
-+        char * _cEscapedString = escape_double_quotes( file[0] );
-+        sprintf( command, "find \"%s\" -type f | wc -l", _cEscapedString );
-+        free( _cEscapedString );
 +        FILE *fp ;
 +        char output[1024];
-+        fp = popen(command,"r");
-+        if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
++        char fcmd[] = "find";
++        fp = spawn(fcmd, (char *[]){ fcmd, file[0], NULL, "-type", "f", NULL });
++        if ( fp == NULL)
 +            printf("failed to run find\r");
 +        else
-+            if ( atoi(output) > n_files )
-+              g_iTotalFiles = atoi( output );
++        {
++          char *line_buf = NULL;
++          size_t line_buf_size = 0;
++          int line_count = 0;
++          ssize_t line_size;
++          line_size = getline(&line_buf, &line_buf_size, fp);
++          while (line_size > 0)
++          {
++              line_count++;
++              line_size = getline(&line_buf, &line_buf_size, fp);
++          }
++          free (line_buf);
++          if ( line_count > n_files )
++            g_iTotalFiles = line_count;
++        }
 +
 +        for (j = 0; j < iFiles; j++)
 +        {
 +          /* call du -s for each file */
-+          /* create command */
-+          char command[1024];
-+          char * _cEscapedString = escape_double_quotes( file[j] );
-+          sprintf ( command, "du -s \"%s\"", _cEscapedString );
-+          free( _cEscapedString );
-+
-+          FILE *fp;
-+          char output[1024];
-+
-+          /* run command */
-+          fp = popen(command, "r");
++          char dcmd[] = "du";
++          fp = spawn(dcmd, (char *[]){ dcmd, "-s", file[j], NULL });
 +          if (fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL) {
 +            printf("failed to run du\r" );
 +          }
@@ -623,7 +636,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
  
    if (target_directory)
      {
-@@ -777,6 +864,56 @@
+@@ -777,6 +865,56 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -671,7 +684,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 +          sprintf ( sFType, "%s", "file(s)" );
 +
 +        char f_time[20];
-+        format_time(f_time, sec_elapsed, true);
++        format_time(f_time, sec_elapsed, false);
 +        printf ( "%d %s (%s) copied in %s (%s/s).\n", g_iFilesCopied, sFType,
 +                 sTotalWritten, f_time, s_copy_speed );
 +    }
@@ -680,7 +693,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
    return ok;
  }
  
-@@ -812,6 +949,11 @@
+@@ -812,6 +950,11 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
@@ -692,7 +705,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
    x->set_mode = false;
    x->mode = 0;
  
-@@ -950,7 +1092,8 @@
+@@ -950,7 +1093,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -702,7 +715,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1007,6 +1150,12 @@
+@@ -1007,6 +1151,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
@@ -717,7 +730,7 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
            break;
 diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 --- coreutils-8.32/src/mv.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/mv.c	2022-01-12 20:08:19.577923660 +0100
++++ coreutils-8.32-patched/src/mv.c	2022-02-13 16:14:31.542047802 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -728,7 +741,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -170,8 +173,124 @@
+@@ -170,8 +173,130 @@
  {
    bool copy_into_self;
    bool rename_succeeded;
@@ -755,30 +768,36 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 +    g_oStartTime = start_time;
 +
 +    /* how many files are we copying */
-+    char command[1024];
-+    char output[1024];
 +    FILE *fp ;
-+
-+    char * _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
-+    sprintf( command, "find \"%s\" -type f | wc -l", _cEscapedString );
-+    free( _cEscapedString );
-+    fp = popen(command,"r");
-+    if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
++    char output[1024];
++    char fcmd[] = "find";
++    fp = spawn(fcmd, (char *[]){ fcmd, (unsigned char *)(size_t)source, NULL, "-type", "f", NULL });
++    if ( fp == NULL)
 +      printf("failed to run find\r");
 +    else
-+      g_iTotalFiles = atoi( output );
++    {
++      char *line_buf = NULL;
++      size_t line_buf_size = 0;
++      int line_count = 0;
++      ssize_t line_size;
++      line_size = getline(&line_buf, &line_buf_size, fp);
++      while (line_size > 0)
++      {
++        line_count++;
++        line_size = getline(&line_buf, &line_buf_size, fp);
++      }
++      free (line_buf);
++      g_iTotalFiles = line_count;
++    }
++    /* close */
++    pclose(fp);
 +
 +    printf ("calculating total size... \r");
 +    fflush (stdout);
 +    long iTotalSize = 0;
 +    /* call du -s for each file */
-+    /* create command */
-+    _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
-+    sprintf ( command, "du -s \"%s\"", _cEscapedString );
-+    free( _cEscapedString );
-+
-+    /* run command */
-+    fp = popen(command, "r");
++    char dcmd[] = "du";
++    fp = spawn(dcmd, (char *[]){ dcmd, "-s", (unsigned char *)(size_t)source, NULL });
 +    if (fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL) {
 +      printf("failed to run du\r" );
 +    }
@@ -843,7 +862,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 +        sprintf ( sFType, "%s", "file(s)" );
 +
 +      char f_time[20];
-+      format_time(f_time, sec_elapsed, true);
++      format_time(f_time, sec_elapsed, false);
 +      printf ( "%d %s (%s) moved in %s (%s/s).\n", g_iFilesCopied, sFType,
 +               sTotalWritten, f_time, s_copy_speed );
 +    }
@@ -853,7 +872,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +425,11 @@
+@@ -306,6 +431,11 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
@@ -865,7 +884,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +485,8 @@
+@@ -361,7 +491,8 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
@@ -875,7 +894,7 @@ diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
           != -1)
      {
        switch (c)
-@@ -407,6 +532,11 @@
+@@ -407,6 +538,11 @@
          case 'v':
            x.verbose = true;
            break;

--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched/src/copy.c	2021-12-23 19:26:40.665650895 +0100
-@@ -129,6 +129,101 @@
++++ coreutils-8.32-patched/src/copy.c	2021-12-24 20:12:31.563582368 +0100
+@@ -129,6 +129,95 @@
    dev_t dev;
  };
  
@@ -16,32 +16,26 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 +
 +char * escape_double_quotes ( char * _cUnescapedString )
 +{
-+  int pos = 0;
-+  int count = 0;
-+  for(pos = 0; _cUnescapedString[pos] != '\0'; pos++)
-+  {
-+    if(_cUnescapedString[pos] == '"')
-+      ++count;
-+  }
-+
 +  char * _cEscapedString;
-+  _cEscapedString = calloc( sizeof(char) * ( pos + 1 + count * 2 ), sizeof(char) );
-+
-+  int epos = 0;
-+  for(pos = 0; _cUnescapedString[pos] != '\0'; pos++)
++  _cEscapedString = (char *) malloc( sizeof(char) * strlen(_cUnescapedString) * 2 );
++  size_t ipos = 0;
++  size_t rpos = 0;
++  for(rpos = 0, ipos = 0; _cUnescapedString[rpos] != '\0'; rpos++, ipos++)
 +  {
-+    if(_cUnescapedString[pos] == '"')
++    if(_cUnescapedString[rpos] == '"')
 +    {
-+      _cEscapedString[epos] = '\\';
-+      epos++;
-+      _cEscapedString[epos] = _cUnescapedString[pos];
++      _cEscapedString[ipos] = '\\';
++      ipos++;
 +    }
-+    else
-+      _cEscapedString[epos] = _cUnescapedString[pos];
-+    epos++;
++    if(_cUnescapedString[rpos] == '`')
++    {
++      _cEscapedString[ipos] = '\\';
++      ipos++;
++    }
++    _cEscapedString[ipos] = _cUnescapedString[rpos];
 +  }
-+  epos++;
-+  _cEscapedString[epos] = '\0';
++  ipos++;
++  _cEscapedString[ipos] = '\0';
 +  return _cEscapedString;
 +}
 +
@@ -103,7 +97,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -259,9 +354,16 @@
+@@ -259,9 +348,16 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes,
@@ -121,7 +115,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -270,6 +372,85 @@
+@@ -270,6 +366,85 @@
  
    while (max_n_read)
      {
@@ -207,7 +201,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -354,6 +535,14 @@
+@@ -354,6 +529,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -222,7 +216,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -420,9 +609,11 @@
+@@ -420,9 +603,11 @@
  static bool
  extent_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, off_t src_total_size,
@@ -236,7 +230,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
  {
    struct extent_scan scan;
    off_t last_ext_start = 0;
-@@ -553,10 +744,26 @@
+@@ -553,10 +738,26 @@
                last_ext_len = ext_len;
                bool read_hole;
  
@@ -265,7 +259,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
                  goto fail;
  
                dest_pos = ext_start + n_read;
-@@ -1305,6 +1512,75 @@
+@@ -1305,6 +1506,75 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -341,7 +335,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
        if (sparse_src)
          {
            bool normal_copy_required;
-@@ -1316,7 +1592,9 @@
+@@ -1316,7 +1586,9 @@
            if (extent_copy (source_desc, dest_desc, buf, buf_size, hole_size,
                             src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
@@ -352,7 +346,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
              goto preserve_metadata;
  
            if (! normal_copy_required)
-@@ -1328,11 +1606,23 @@
+@@ -1328,11 +1600,23 @@
  
        off_t n_read;
        bool wrote_hole_at_eof;
@@ -379,7 +373,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1343,6 +1633,14 @@
+@@ -1343,6 +1627,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -394,7 +388,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
      }
  
  preserve_metadata:
-@@ -1716,15 +2014,15 @@
+@@ -1716,15 +2008,15 @@
        fprintf (stderr,
                 (x->move_mode || x->unlink_dest_before_opening
                  || x->unlink_dest_after_failed_open)

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-01-09 21:17:53.190781361 +0100
-@@ -129,6 +129,119 @@
++++ coreutils-9.0-patched/src/copy.c	2022-01-10 23:37:17.800794586 +0100
+@@ -129,6 +129,122 @@
    dev_t dev;
  };
  
@@ -50,7 +50,10 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  size_t maxneeded = snprintf(NULL, 0, "%2dh %2dm %4.1fs", hr, min, sec) + 1;
 +  char * _cTimeString;
 +  _cTimeString = (char *) calloc( sizeof(char) * maxneeded, sizeof(char) );
-+  if ( seconds >= 3600 || showall)
++  if ( showall )
++  {
++    sprintf(_cTimeString, "%2dh %2dm %2ds", hr, min, (int) sec);
++  } else  if ( seconds >= 3600 )
 +  {
 +    sprintf(_cTimeString, "%2dh %2dm %4.1fs", hr, min, sec);
 +  } else if ( seconds >= 60 )
@@ -121,7 +124,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -300,9 +413,16 @@
+@@ -300,9 +416,16 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes, bool allow_reflink,
@@ -139,7 +142,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -362,6 +482,81 @@
+@@ -362,6 +485,93 @@
  
    while (max_n_read)
      {
@@ -175,11 +178,23 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +            int sec_remaining = ( int ) ( ( double ) isec_elapsed / cur_size
 +              * g_iTotalSize ) - isec_elapsed;
 +            /* print out */
++
++            sprintf ( s_progress->cProgressField[1],
++              move_mode
++                ? "%d of %d files moved (about %s remaining) "
++                : "%d of %d files copied (about %s remaining) ",
++                g_iFilesCopied, g_iTotalFiles, format_time(sec_remaining, true) );
++
++            char s_ftime[100] = "";
++            if (g_iTotalFiles > 1)
++              s_ftime[0] = '\0';
++            else
++              sprintf ( s_ftime, "(about %s remaining)", format_time(sec_remaining, true) );
++
 +            sprintf ( s_progress->cProgressField[3],
 +              move_mode
-+                ? "moving at %s/s (about %s remaining)"
-+                : "copying at %s/s (about %s remaining)", s_copy_speed,
-+              format_time(sec_remaining, true) );
++                ? "moving at %s/s %s"
++                : "copying at %s/s %s", s_copy_speed, s_ftime );
 +
 +            int fs_len;
 +            if ( g_iTotalFiles > 1 )
@@ -221,7 +236,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +641,14 @@
+@@ -446,6 +656,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -236,7 +251,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -517,8 +720,16 @@
+@@ -517,8 +735,16 @@
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
              enum Sparse_type sparse_mode,
@@ -254,7 +269,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +801,26 @@
+@@ -590,10 +816,26 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -283,7 +298,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1601,84 @@
+@@ -1374,8 +1616,82 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -323,12 +338,10 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +
 +        /* show how many files were written */
 +        int sum_length = 0;
-+        if ( x->move_mode )
-+          sum_length = sprintf ( cProgressField[1], "%d of %d files moved so far...",
-+            g_iFilesCopied, g_iTotalFiles );
-+        else
-+          sum_length = sprintf ( cProgressField[1], "%d of %d files copied so far...",
-+            g_iFilesCopied, g_iTotalFiles );
++        sum_length = sprintf ( cProgressField[1],
++          x->move_mode
++            ? "%d of %d files moved so far"
++            : "%d of %d files copied so far", g_iFilesCopied, g_iTotalFiles );
 +        cProgressField[1][sum_length] = ' ';
 +      }
 +
@@ -368,7 +381,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1686,30 @@
+@@ -1383,15 +1699,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -401,7 +414,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1720,14 @@
+@@ -1402,6 +1733,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -418,7 +431,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-01-09 21:17:53.194781413 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-01-10 23:37:17.800794586 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -453,7 +466,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-01-09 21:17:53.194781413 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-01-10 23:37:17.804794633 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -665,7 +678,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-01-09 21:17:53.194781413 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-01-10 23:37:17.804794633 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-01-10 23:37:17.800794586 +0100
-@@ -129,6 +129,122 @@
++++ coreutils-9.0-patched/src/copy.c	2022-01-11 20:51:54.334645363 +0100
+@@ -129,6 +129,125 @@
    dev_t dev;
  };
  
@@ -52,7 +52,10 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  _cTimeString = (char *) calloc( sizeof(char) * maxneeded, sizeof(char) );
 +  if ( showall )
 +  {
-+    sprintf(_cTimeString, "%2dh %2dm %2ds", hr, min, (int) sec);
++    if ( seconds < 0 )
++      sprintf(_cTimeString, "%2ch %2cm %2cs", '0', '0', '?');
++    else
++      sprintf(_cTimeString, "%2dh %2dm %2ds", hr, min, (int) sec);
 +  } else  if ( seconds >= 3600 )
 +  {
 +    sprintf(_cTimeString, "%2dh %2dm %4.1fs", hr, min, sec);
@@ -124,7 +127,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -300,9 +416,16 @@
+@@ -300,13 +419,28 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes, bool allow_reflink,
@@ -142,7 +145,19 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -362,6 +485,93 @@
+ 
++  /* BEGIN progress mod */
++  gettimeofday ( & g_oFStartTime, NULL );
++  g_iFTotalWritten = 0;
++  struct stat st;
++  stat(src_name, &st);
++  g_iFTotalSize = st.st_size/1024;
++  /* END progress mod */
++
+   /* If not looking for holes, use copy_file_range if functional,
+      but don't use if reflink disallowed as that may be implicit.  */
+   if ((! hole_size) && allow_reflink && functional_copy_file_range ())
+@@ -362,6 +496,97 @@
  
    while (max_n_read)
      {
@@ -162,6 +177,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +            struct timeval cur_time;
 +            gettimeofday ( & cur_time, NULL );
 +            int cur_size = g_iTotalWritten + *total_n_read / 1024;
++            int cur_fsize = g_iFTotalWritten + *total_n_read / 1024;
 +            int usec_elapsed = cur_time.tv_usec - s_progress->last_time.tv_usec;
 +            double sec_elapsed = ( double ) usec_elapsed / 1000000.f;
 +            sec_elapsed += ( double ) ( cur_time.tv_sec - s_progress->last_time.tv_sec );
@@ -175,8 +191,11 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +
 +            /* how many time has passed since the start? */
 +            int isec_elapsed = cur_time.tv_sec - g_oStartTime.tv_sec;
++            int isec_felapsed = cur_time.tv_sec - g_oFStartTime.tv_sec;
 +            int sec_remaining = ( int ) ( ( double ) isec_elapsed / cur_size
 +              * g_iTotalSize ) - isec_elapsed;
++            int sec_fremaining = ( int ) ( ( double ) isec_felapsed / cur_fsize
++              * g_iFTotalSize ) - isec_felapsed;
 +            /* print out */
 +
 +            sprintf ( s_progress->cProgressField[1],
@@ -187,7 +206,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +
 +            char s_ftime[100] = "";
 +            if (g_iTotalFiles > 1)
-+              s_ftime[0] = '\0';
++              sprintf ( s_ftime, "(about %s remaining)", format_time(sec_fremaining, true) );
 +            else
 +              sprintf ( s_ftime, "(about %s remaining)", format_time(sec_remaining, true) );
 +
@@ -236,7 +255,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +656,14 @@
+@@ -446,6 +671,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -251,7 +270,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -517,8 +735,16 @@
+@@ -517,8 +750,16 @@
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
              enum Sparse_type sparse_mode,
@@ -269,7 +288,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +816,26 @@
+@@ -590,10 +831,26 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -298,7 +317,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1616,82 @@
+@@ -1374,8 +1631,82 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -381,7 +400,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1699,30 @@
+@@ -1383,15 +1714,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -414,7 +433,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1733,14 @@
+@@ -1402,6 +1748,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -431,7 +450,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-01-10 23:37:17.800794586 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-01-11 20:51:54.334645363 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -444,7 +463,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -308,4 +313,19 @@
+@@ -308,4 +313,22 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
@@ -455,10 +474,13 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
 +__attribute__((__common__)) long g_iTotalSize;
++__attribute__((__common__)) long g_iFTotalSize;
 +__attribute__((__common__)) long g_iTotalWritten;
++__attribute__((__common__)) long g_iFTotalWritten;
 +__attribute__((__common__)) int g_iFilesCopied;
 +__attribute__((__common__)) int g_iDirectoriesCopied;
 +__attribute__((__common__)) struct timeval g_oStartTime;
++__attribute__((__common__)) struct timeval g_oFStartTime;
 +__attribute__((__common__)) int g_iTotalFiles;
 +__attribute__((__common__)) bool progress;
 +/* END progress mod */
@@ -466,7 +488,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-01-10 23:37:17.804794633 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-01-11 20:51:54.338645406 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -678,7 +700,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-01-10 23:37:17.804794633 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-01-11 20:51:54.338645406 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-23 19:13:54.313100934 +0100
-@@ -129,6 +129,101 @@
++++ coreutils-9.0-patched/src/copy.c	2021-12-24 20:07:37.109671577 +0100
+@@ -129,6 +129,95 @@
    dev_t dev;
  };
  
@@ -16,32 +16,26 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +
 +char * escape_double_quotes ( char * _cUnescapedString )
 +{
-+  int pos = 0;
-+  int count = 0;
-+  for(pos = 0; _cUnescapedString[pos] != '\0'; pos++)
-+  {
-+    if(_cUnescapedString[pos] == '"')
-+      ++count;
-+  }
-+
 +  char * _cEscapedString;
-+  _cEscapedString = calloc( sizeof(char) * ( pos + 1 + count * 2 ), sizeof(char) );
-+
-+  int epos = 0;
-+  for(pos = 0; _cUnescapedString[pos] != '\0'; pos++)
++  _cEscapedString = (char *) malloc( sizeof(char) * strlen(_cUnescapedString) * 2 );
++  size_t ipos = 0;
++  size_t rpos = 0;
++  for(rpos = 0, ipos = 0; _cUnescapedString[rpos] != '\0'; rpos++, ipos++)
 +  {
-+    if(_cUnescapedString[pos] == '"')
++    if(_cUnescapedString[rpos] == '"')
 +    {
-+      _cEscapedString[epos] = '\\';
-+      epos++;
-+      _cEscapedString[epos] = _cUnescapedString[pos];
++      _cEscapedString[ipos] = '\\';
++      ipos++;
 +    }
-+    else
-+      _cEscapedString[epos] = _cUnescapedString[pos];
-+    epos++;
++    if(_cUnescapedString[rpos] == '`')
++    {
++      _cEscapedString[ipos] = '\\';
++      ipos++;
++    }
++    _cEscapedString[ipos] = _cUnescapedString[rpos];
 +  }
-+  epos++;
-+  _cEscapedString[epos] = '\0';
++  ipos++;
++  _cEscapedString[ipos] = '\0';
 +  return _cEscapedString;
 +}
 +
@@ -103,7 +97,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -300,9 +395,16 @@
+@@ -300,9 +389,16 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes, bool allow_reflink,
@@ -121,7 +115,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -362,6 +464,85 @@
+@@ -362,6 +458,85 @@
  
    while (max_n_read)
      {
@@ -207,7 +201,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +627,14 @@
+@@ -446,6 +621,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -222,7 +216,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -517,8 +706,16 @@
+@@ -517,8 +700,16 @@
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
              enum Sparse_type sparse_mode,
@@ -240,7 +234,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +787,26 @@
+@@ -590,10 +781,26 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -269,7 +263,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1587,82 @@
+@@ -1374,8 +1581,82 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -352,7 +346,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1670,30 @@
+@@ -1383,15 +1664,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -385,7 +379,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1704,14 @@
+@@ -1402,6 +1698,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-25 10:56:28.094604761 +0100
++++ coreutils-9.0-patched/src/copy.c	2021-12-25 11:08:37.969704196 +0100
 @@ -129,6 +129,95 @@
    dev_t dev;
  };
@@ -17,7 +17,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +char * escape_double_quotes ( char * _cUnescapedString )
 +{
 +  char * _cEscapedString;
-+  _cEscapedString = (char *) malloc( sizeof(char) * strlen(_cUnescapedString) * 2 );
++  _cEscapedString = (char *) calloc( sizeof(char) * strlen(_cUnescapedString) * 2, sizeof(char) );
 +  size_t ipos = 0;
 +  size_t rpos = 0;
 +  for(rpos = 0, ipos = 0; _cUnescapedString[rpos] != '\0'; rpos++, ipos++)

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -539,7 +539,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2021-12-22 14:06:01.609250389 +0100
++++ coreutils-9.0-patched/src/mv.c	2021-12-22 14:16:55.425936987 +0100
 @@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -572,7 +572,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    /* call du -s for each file */
 +    /* create command */
 +    char command[1024];
-+    sprintf ( command, "du -s '%s'", source );
++    sprintf ( command, "du -s \"%s\"", source );
 +    /* TODO: replace all quote signs in file[i] */
 +
 +    FILE *fp;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-01-11 22:10:44.509858035 +0100
++++ coreutils-9.0-patched/src/copy.c	2022-01-11 23:26:31.735507217 +0100
 @@ -129,6 +129,121 @@
    dev_t dev;
  };
@@ -203,7 +203,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +              move_mode
 +                ? "%d of %d files moved (about %s remaining) "
 +                : "%d of %d files copied (about %s remaining) ",
-+                g_iFilesCopied, g_iTotalFiles, f_ftime );
++                g_iFilesCopied, g_iTotalFiles, f_ttime );
 +
 +            char s_ftime[40] = "";
 +
@@ -452,7 +452,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-01-11 22:10:44.509858035 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-01-11 23:26:31.739507270 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -490,7 +490,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-01-11 22:10:44.513858084 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-01-11 23:26:31.743507323 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -705,7 +705,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-01-11 22:10:44.513858084 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-01-11 23:26:31.743507323 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-23 18:50:20.771131070 +0100
++++ coreutils-9.0-patched/src/copy.c	2021-12-23 19:13:54.313100934 +0100
 @@ -129,6 +129,101 @@
    dev_t dev;
  };
@@ -269,7 +269,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1587,78 @@
+@@ -1374,8 +1587,82 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -308,7 +308,11 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +        file_size_format ( cProgressField[1] + iBarLength - 9, g_iTotalSize, 1 );
 +
 +        /* show how many files were written */
-+        int sum_length = sprintf ( cProgressField[1], "%d files copied so far...", g_iFilesCopied );
++        int sum_length = 0;
++        if ( x->move_mode )
++          sum_length = sprintf ( cProgressField[1], "%d files moved so far...", g_iFilesCopied );
++        else
++          sum_length = sprintf ( cProgressField[1], "%d files copied so far...", g_iFilesCopied );
 +        cProgressField[1][sum_length] = ' ';
 +      }
 +
@@ -348,7 +352,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1666,30 @@
+@@ -1383,15 +1670,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -381,7 +385,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1700,14 @@
+@@ -1402,6 +1704,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -623,7 +627,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2021-12-23 18:47:22.480010369 +0100
++++ coreutils-9.0-patched/src/mv.c	2021-12-23 19:15:58.867551600 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -634,7 +638,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -170,8 +173,106 @@
+@@ -170,8 +173,121 @@
  {
    bool copy_into_self;
    bool rename_succeeded;
@@ -645,6 +649,8 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +  if(progress && x->rename_errno != 0) {
 +    if (g_iTotalSize == 0)
 +      g_iTotalSize = 0;
++    if (g_iTotalFiles == 0)
++      g_iTotalFiles = 0;
 +    if (g_iFilesCopied == 0)
 +      g_iFilesCopied = 0;
 +    if (g_iDirectoriesCopied == 0)
@@ -658,18 +664,28 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    gettimeofday (& start_time, NULL);
 +    g_oStartTime = start_time;
 +
++    /* how many files are we copying */
++    char command[1024];
++    char output[1024];
++    FILE *fp ;
++
++    char * _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
++    sprintf( command, "find \"%s\" -type f | wc -l", _cEscapedString );
++    free( _cEscapedString );
++    fp = popen(command,"r");
++    if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
++      printf("failed to run find\r");
++    else
++      g_iTotalFiles = atoi( output );
++
 +    printf ("calculating total size... \r");
 +    fflush (stdout);
 +    long iTotalSize = 0;
 +    /* call du -s for each file */
 +    /* create command */
-+    char command[1024];
-+    char * _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
++    _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
 +    sprintf ( command, "du -s \"%s\"", _cEscapedString );
 +    free( _cEscapedString );
-+
-+    FILE *fp;
-+    char output[1024];
 +
 +    /* run command */
 +    fp = popen(command, "r");
@@ -698,9 +714,12 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    /* remove everything */
 +    int i;
 +    int limit = (g_iTotalFiles > 1 ? 6 : 3);
-+    for ( i = 0; i < limit; i++ )
-+      printf ( "\033[K\n" );
-+    printf ( "\r\033[3A" );
++    if (!rename_succeeded)
++    {
++      for ( i = 0; i < limit; i++ )
++        printf ( "\033[K\n" );
++      printf ( "\r\033[3A" );
++    }
 +
 +    /* save time */
 +    struct timeval end_time;
@@ -741,7 +760,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +407,11 @@
+@@ -306,6 +422,11 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
@@ -753,7 +772,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +467,8 @@
+@@ -361,7 +482,8 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
@@ -763,7 +782,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
           != -1)
      {
        switch (c)
-@@ -407,6 +514,11 @@
+@@ -407,6 +529,11 @@
          case 'v':
            x.verbose = true;
            break;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,10 +1,11 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-22 20:21:15.702583886 +0100
++++ coreutils-9.0-patched/src/copy.c	2021-12-23 09:03:07.290374485 +0100
 @@ -129,6 +129,101 @@
    dev_t dev;
  };
  
++/* BEGIN progress mod */
 +struct progress_status {
 +  int iCountDown;
 +  char ** cProgressField;
@@ -13,7 +14,6 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  struct stat src_open_sb;
 +};
 +
-+/* BEGIN progress mod */
 +char * escape_double_quotes ( char * _cUnescapedString )
 +{
 +  int pos = 0;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-23 11:35:19.632502471 +0100
++++ coreutils-9.0-patched/src/copy.c	2021-12-23 18:50:20.771131070 +0100
 @@ -129,6 +129,101 @@
    dev_t dev;
  };
@@ -163,8 +163,8 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +            /* print out */
 +            sprintf ( s_progress->cProgressField[3],
 +              move_mode
-+                ? "Moving at %s/s (about %uh %um %us remaining)"
-+                : "Copying at %s/s (about %uh %um %us remaining)", s_copy_speed,
++                ? "moving at %s/s (about %uh %um %us remaining)"
++                : "copying at %s/s (about %uh %um %us remaining)", s_copy_speed,
 +              hours_remaining, min_remaining, sec_remaining );
 +
 +            int fs_len;
@@ -398,7 +398,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2021-12-23 09:37:38.015722020 +0100
++++ coreutils-9.0-patched/src/copy.h	2021-12-23 18:38:01.481129523 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -432,7 +432,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2021-12-23 11:44:06.012603217 +0100
++++ coreutils-9.0-patched/src/cp.c	2021-12-23 18:46:20.692530921 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -473,7 +473,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +        gettimeofday ( & start_time, NULL );
 +        g_oStartTime = start_time;
 +
-+        printf ( "Calculating total size... \r" );
++        printf ( "calculating total size... \r" );
 +        fflush ( stdout );
 +        long iTotalSize = 0;
 +        int iFiles = n_files;
@@ -490,7 +490,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +        char output[1024];
 +        fp = popen(command,"r");
 +        if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
-+            printf("failed to run find.\n");
++            printf("failed to run find\r");
 +        else
 +            g_iTotalFiles = atoi( output );
 +
@@ -509,7 +509,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +          /* run command */
 +          fp = popen(command, "r");
 +          if (fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL) {
-+            printf("failed to run du.\n" );
++            printf("failed to run du\r" );
 +          }
 +          else
 +          {
@@ -517,7 +517,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +            strchr ( output, '\t' )[0] = '\0';
 +            iTotalSize += atol ( output );
 +
-+            printf ( "Calculating total size... %ld\r", iTotalSize );
++            printf ( "calculating total size... %ld\r", iTotalSize );
 +            fflush ( stdout );
 +          }
 +
@@ -623,7 +623,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2021-12-23 11:57:51.221688967 +0100
++++ coreutils-9.0-patched/src/mv.c	2021-12-23 18:47:22.480010369 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -658,7 +658,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    gettimeofday (& start_time, NULL);
 +    g_oStartTime = start_time;
 +
-+    printf ("Calculating total size... \r");
++    printf ("calculating total size... \r");
 +    fflush (stdout);
 +    long iTotalSize = 0;
 +    /* call du -s for each file */
@@ -674,14 +674,14 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    /* run command */
 +    fp = popen(command, "r");
 +    if (fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL) {
-+      //printf("failed to run du.\n" );
++      printf("failed to run du\r" );
 +    }
 +    else
 +    {
 +      /* isolate size */
 +      strchr ( output, '\t' )[0] = '\0';
 +      iTotalSize += atol ( output );
-+      printf ( "Calculating total size... %ld\r", iTotalSize );
++      printf ( "calculating total size... %ld\r", iTotalSize );
 +      fflush ( stdout );
 +    }
 +

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-22 13:44:23.687642989 +0100
++++ coreutils-9.0-patched/src/copy.c	2021-12-22 13:54:37.773464626 +0100
 @@ -129,6 +129,70 @@
    dev_t dev;
  };
@@ -13,7 +13,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  struct stat src_open_sb;
 +};
 +
-+/* Begin progress Mod*/
++/* BEGIN progress mod */
 +static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
 +{
 +    double dPercent = (double) _lProgress / (double) _lTotal * 100.f;
@@ -333,7 +333,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2021-12-22 13:37:29.730204394 +0100
++++ coreutils-9.0-patched/src/copy.h	2021-12-22 13:54:36.317440119 +0100
 @@ -236,6 +236,9 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -348,7 +348,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
-+/* BEGIN OF PROGRESS MOD */
++/* BEGIN progress mod */
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
 +__attribute__((__common__)) long g_iTotalSize;
@@ -357,7 +357,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 +__attribute__((__common__)) struct timeval g_oStartTime;
 +__attribute__((__common__)) int g_iTotalFiles;
 +__attribute__((__common__)) bool progress;
-+/* END OF PROGRESS MOD */
++/* END progress mod */
 +
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-22 13:54:37.773464626 +0100
++++ coreutils-9.0-patched/src/copy.c	2021-12-22 14:00:42.663699889 +0100
 @@ -129,6 +129,70 @@
    dev_t dev;
  };
@@ -91,8 +91,8 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    while (max_n_read)
      {
 +
++    /* BEGIN progress mod */
 +    if (progress) {
-+          /* BEGIN progress mod */
 +          /* update countdown */
 +          s_progress->iCountDown--;
 +          char * sProgressBar = s_progress->cProgressField[5];
@@ -166,8 +166,8 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +              printf ( "\r\033[3A" );
 +            fflush ( stdout );
 +          }
-+          /* END progress mod */
 +      }
++      /* END progress mod */
 +
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
@@ -320,7 +320,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
            return_val = false;
            goto close_src_and_dst_desc;
          }
-+       /* BEGIN progress mod */
++      /* BEGIN progress mod */
 +      if (progress) {
 +            int i;
 +            for ( i = 0; i < 6; i++ )
@@ -362,7 +362,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2021-12-22 13:38:59.519244777 +0100
++++ coreutils-9.0-patched/src/cp.c	2021-12-22 14:02:52.053943727 +0100
 @@ -131,6 +131,7 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -385,9 +385,9 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
++    /* BEGIN progress mod */
 +    struct timeval start_time;
 +    if (progress) {
-+        /* BEGIN progress mod */
 +        g_iTotalSize = 0;
 +        g_iTotalFiles = 0;
 +        g_iFilesCopied = 0;
@@ -446,8 +446,8 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +          pclose(fp);
 +        }
 +        g_iTotalSize = iTotalSize;
-+        /* END progress mod */
 +    }
++    /* END progress mod */
 +
  
    if (target_directory)
@@ -456,8 +456,8 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
++    /* BEGIN progress mod */
 +    if (progress) {
-+        /* BEGIN progress mod */
 +        /* remove everything */
 +        int i;
 +        if ( g_iTotalFiles > 1 )
@@ -493,8 +493,8 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +        /* good-bye message */
 +        printf ( "%d files (%s) copied in %.1f seconds (%s/s).\n", g_iFilesCopied, sTotalWritten,
 +                 sec_elapsed, s_copy_speed );
-+        /* END progress mod */
 +    }
++    /* END progress mod */
 +
    return ok;
  }
@@ -539,7 +539,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2021-12-22 13:37:58.306524898 +0100
++++ coreutils-9.0-patched/src/mv.c	2021-12-22 14:06:01.609250389 +0100
 @@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -556,8 +556,9 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +
    bool copy_into_self;
    bool rename_succeeded;
++
++  /* BEGIN progress mod */
 +  if(progress && x->rename_errno != 0) {
-+    /* BEGIN progress mod */
 +    g_iTotalSize = 0;
 +    g_iFilesCopied = 0;
 +    g_iTotalWritten = 0;
@@ -594,14 +595,13 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    /* close */
 +    pclose(fp);
 +    g_iTotalSize = iTotalSize;
-+    /* END progress mod */
-+
 +  }
++  /* END progress mod */
 +
    bool ok = copy (source, dest, false, x, &copy_into_self, &rename_succeeded);
  
++  /* BEGIN progress mod */
 +  if (progress && (x->rename_errno != 0 && ok)) {
-+    /* BEGIN progress mod */
 +    /* remove everything */
 +    int i;
 +    int limit = (g_iTotalFiles > 1 ? 6 : 3);
@@ -629,8 +629,8 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    /* good-bye message */
 +    printf ( "%d files (%s) moved in %.1f seconds (%s/s).\n", g_iFilesCopied, sTotalWritten,
 +             sec_elapsed, s_copy_speed );
-+    /* END progress mod */
 +  }
++  /* END progress mod */
 +
    if (ok)
      {

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,41 +1,41 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
---- coreutils-9.0/src/copy.c	2021-09-24 07:31:05.000000000 -0400
-+++ coreutils-9.0-patched/src/copy.c	2021-10-27 21:33:32.299248300 -0400
+--- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
++++ coreutils-9.0-patched/src/copy.c	2021-12-22 13:44:23.687642989 +0100
 @@ -129,6 +129,70 @@
    dev_t dev;
  };
  
-+struct progress_status { 
-+  int iCountDown; 
-+  char ** cProgressField; 
-+  struct timeval last_time; 
-+  int last_size, iBarLength; 
-+  struct stat src_open_sb; 
-+}; 
++struct progress_status {
++  int iCountDown;
++  char ** cProgressField;
++  struct timeval last_time;
++  int last_size, iBarLength;
++  struct stat src_open_sb;
++};
 +
-+/* Begin progress Mod*/ 
-+static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal ) 
-+{ 
-+    double dPercent = (double) _lProgress / (double) _lTotal * 100.f; 
++/* Begin progress Mod*/
++static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
++{
++    double dPercent = (double) _lProgress / (double) _lTotal * 100.f;
 +    sprintf( _cDest + ( _iBarLength - 6), "%4.1f", dPercent );
-+    _cDest[_iBarLength - 2] = ' '; 
++    _cDest[_iBarLength - 2] = ' ';
 +
-+    int i; 
-+    for ( i=1; i<=_iBarLength - 9; i++) 
-+    { 
++    int i;
++    for ( i=1; i<=_iBarLength - 9; i++)
++    {
 +        if ( dPercent > (double) (i-1) / (_iBarLength - 10) * 100.f )
 +        {
-+            _cDest[i] = '='; 
++            _cDest[i] = '=';
 +        }
-+        else 
++        else
 +        {
-+            _cDest[i] = ' '; 
++            _cDest[i] = ' ';
 +        }
 +    }
-+    for ( i=1; i<_iBarLength - 9; i++) 
-+    { 
++    for ( i=1; i<_iBarLength - 9; i++)
++    {
 +        if ( ( _cDest[i+1] == ' ' ) && ( _cDest[i] == '=' ) )
-+            _cDest[i] = '>' ; 
++            _cDest[i] = '>' ;
 +    }
 +}
 +
@@ -95,7 +95,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +          /* BEGIN progress mod */
 +          /* update countdown */
 +          s_progress->iCountDown--;
-+          char * sProgressBar = s_progress->cProgressField[5]; 
++          char * sProgressBar = s_progress->cProgressField[5];
 +          if ( s_progress->iCountDown < 0 )
 +            s_progress->iCountDown = 100;
 +
@@ -153,7 +153,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +            s_progress->cProgressField[4][s_progress->iBarLength - 21 + fs_len] = ' ';
 +
 +            /* print the field */
-+            int it; 
++            int it;
 +            for ( it = g_iTotalFiles>1 ? 0 : 3; it < 6; it++ )
 +            {
 +              printf ( "\033[K%s\n", s_progress->cProgressField[it] );
@@ -332,14 +332,14 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
---- coreutils-9.0/src/copy.h	2021-09-24 07:31:05.000000000 -0400
-+++ coreutils-9.0-patched/src/copy.h	2021-10-27 21:33:32.299248300 -0400
+--- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
++++ coreutils-9.0-patched/src/copy.h	2021-12-22 13:37:29.730204394 +0100
 @@ -236,6 +236,9 @@
       Create destination directories as usual. */
    bool symbolic_link;
  
-+  /* If true, draw a nice progress bar on screen */ 
-+  bool progress_bar; 
++  /* If true, draw a nice progress bar on screen */
++  bool progress_bar;
 +
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
@@ -357,12 +357,12 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 +__attribute__((__common__)) struct timeval g_oStartTime;
 +__attribute__((__common__)) int g_iTotalFiles;
 +__attribute__((__common__)) bool progress;
-+/* END OF PROGRESS MOD */ 
++/* END OF PROGRESS MOD */
 +
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
---- coreutils-9.0/src/cp.c	2021-09-24 07:31:05.000000000 -0400
-+++ coreutils-9.0-patched/src/cp.c	2021-10-27 21:22:08.913768100 -0400
+--- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
++++ coreutils-9.0-patched/src/cp.c	2021-12-22 13:38:59.519244777 +0100
 @@ -131,6 +131,7 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -405,16 +405,16 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +          iFiles = n_files - 1;
 +        int j;
 +
-+        /* how many files are we copying */ 
-+        char command[1024]; 
-+        sprintf( command, "find \"%s\" -type f | wc -l", file[0]); 
-+        FILE *fp ; 
-+        char output[1024]; 
++        /* how many files are we copying */
++        char command[1024];
++        sprintf( command, "find \"%s\" -type f | wc -l", file[0]);
++        FILE *fp ;
++        char output[1024];
 +        fp = popen(command,"r");
 +        if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
-+            printf("failed to run find.\n"); 
-+        else 
-+            g_iTotalFiles = atoi( output ) ; 
++            printf("failed to run find.\n");
++        else
++            g_iTotalFiles = atoi( output );
 +
 +        for (j = 0; j < iFiles; j++)
 +        {
@@ -520,9 +520,9 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
            x.unlink_dest_after_failed_open = true;
            break;
  
-+        case 'g': 
-+          progress = true; 
-+          break; 
++        case 'g':
++          progress = true;
++          break;
 +
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
@@ -538,8 +538,8 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                     ? xget_version (_("backup type"),
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
---- coreutils-9.0/src/mv.c	2021-09-24 07:31:05.000000000 -0400
-+++ coreutils-9.0-patched/src/mv.c	2021-10-27 21:33:32.299248300 -0400
+--- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
++++ coreutils-9.0-patched/src/mv.c	2021-12-22 13:37:58.306524898 +0100
 @@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -656,8 +656,8 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
          case 'v':
            x.verbose = true;
            break;
-+        case 'g': 
-+          progress = true; 
++        case 'g':
++          progress = true;
 +          break;
          case 'S':
            make_backups = true;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-25 11:08:37.969704196 +0100
-@@ -129,6 +129,95 @@
++++ coreutils-9.0-patched/src/copy.c	2022-01-04 21:09:38.656916500 +0100
+@@ -129,6 +129,119 @@
    dev_t dev;
  };
  
@@ -37,6 +37,30 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  ipos++;
 +  _cEscapedString[ipos] = '\0';
 +  return _cEscapedString;
++}
++
++char * format_elapsed_time ( double sec_elapsed )
++{
++  // hours
++  long hr = ( (int) sec_elapsed / (60 * 60)) % 24;
++  // minutes
++  int min = ( (int) sec_elapsed / 60) % 60;
++  // seconds
++  double sec = sec_elapsed - (hr * (60 * 60)) - (min * 60);
++  size_t maxneeded = snprintf(NULL, 0, "%ldh %dm %.1fs", hr, min, sec) + 1;
++  char * _cElapsedTimeString;
++  _cElapsedTimeString = (char *) calloc( sizeof(char) * maxneeded, sizeof(char) );
++  if ( sec_elapsed >= 3600 )
++  {
++    sprintf(_cElapsedTimeString, "%ldh %dm %.1fs", hr, min, sec);
++  } else if ( sec_elapsed >= 60 )
++  {
++    sprintf(_cElapsedTimeString, "%dm %.1fs", min, sec);
++  } else
++  {
++    sprintf(_cElapsedTimeString, "%.1fs", sec);
++  }
++  return _cElapsedTimeString;
 +}
 +
 +static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
@@ -97,7 +121,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -300,9 +389,16 @@
+@@ -300,9 +413,16 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes, bool allow_reflink,
@@ -115,7 +139,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -362,6 +458,85 @@
+@@ -362,6 +482,85 @@
  
    while (max_n_read)
      {
@@ -201,7 +225,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +621,14 @@
+@@ -446,6 +645,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -216,7 +240,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -517,8 +700,16 @@
+@@ -517,8 +724,16 @@
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
              enum Sparse_type sparse_mode,
@@ -234,7 +258,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +781,26 @@
+@@ -590,10 +805,26 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -263,7 +287,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1581,82 @@
+@@ -1374,8 +1605,82 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -346,7 +370,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1664,30 @@
+@@ -1383,15 +1688,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -379,7 +403,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1698,14 @@
+@@ -1402,6 +1722,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -396,7 +420,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2021-12-23 18:38:01.481129523 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-01-04 21:09:38.660916566 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -409,12 +433,13 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -308,4 +313,18 @@
+@@ -308,4 +313,19 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
 +/* BEGIN progress mod */
 +char * escape_double_quotes ( char * _cUnescapedString );
++char * format_elapsed_time ( double sec_elapsed );
 +
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
@@ -430,7 +455,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2021-12-25 11:00:50.346873872 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-01-04 21:09:38.660916566 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -585,8 +610,8 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +          sprintf ( sFType, "%s", "folder(s)/file(s)" );
 +        else
 +          sprintf ( sFType, "%s", "file(s)" );
-+        printf ( "%d %s (%s) copied in %.1f seconds (%s/s).\n", g_iFilesCopied, sFType,
-+                 sTotalWritten, sec_elapsed, s_copy_speed );
++        printf ( "%d %s (%s) copied in %s (%s/s).\n", g_iFilesCopied, sFType,
++                 sTotalWritten, format_elapsed_time(sec_elapsed), s_copy_speed );
 +    }
 +    /* END progress mod */
 +
@@ -638,7 +663,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2021-12-23 19:15:58.867551600 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-01-04 21:09:38.660916566 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -762,8 +787,8 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +        sprintf ( sFType, "%s", "folder(s)/file(s)" );
 +      else
 +        sprintf ( sFType, "%s", "file(s)" );
-+      printf ( "%d %s (%s) moved in %.1f seconds (%s/s).\n", g_iFilesCopied, sFType,
-+               sTotalWritten, sec_elapsed, s_copy_speed );
++      printf ( "%d %s (%s) moved in %s (%s/s).\n", g_iFilesCopied, sFType,
++               sTotalWritten, format_elapsed_time(sec_elapsed), s_copy_speed );
 +    }
 +  }
 +  /* END progress mod */

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-24 20:07:37.109671577 +0100
++++ coreutils-9.0-patched/src/copy.c	2021-12-25 10:56:28.094604761 +0100
 @@ -129,6 +129,95 @@
    dev_t dev;
  };
@@ -430,7 +430,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2021-12-23 18:46:20.692530921 +0100
++++ coreutils-9.0-patched/src/cp.c	2021-12-25 11:00:50.346873872 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -455,17 +455,26 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -634,6 +644,73 @@
+@@ -634,6 +644,83 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
 +    /* BEGIN progress mod */
 +    struct timeval start_time;
 +    if (progress) {
-+        g_iTotalSize = 0;
-+        g_iTotalFiles = 0;
-+        g_iFilesCopied = 0;
-+        g_iTotalWritten = 0;
++        if (g_iTotalSize == 0)
++          g_iTotalSize = 0;
++        if (g_iTotalFiles == 0)
++          g_iTotalFiles = n_files;
++        if (g_iFilesCopied == 0)
++          g_iFilesCopied = 0;
++        if (g_iDirectoriesCopied == 0)
++          g_iDirectoriesCopied = 0;
++        if (g_iTotalWritten == 0)
++          g_iTotalWritten = 0;
++
++        if (target_directory_operand (file[0], &sb, &new_dst, forcing))
++          g_iDirectoriesCopied++;
 +
 +        /* save time */
 +        gettimeofday ( & start_time, NULL );
@@ -490,7 +499,8 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +        if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
 +            printf("failed to run find\r");
 +        else
-+            g_iTotalFiles = atoi( output );
++            if ( atoi(output) > n_files )
++              g_iTotalFiles = atoi( output );
 +
 +        for (j = 0; j < iFiles; j++)
 +        {
@@ -522,14 +532,14 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +          /* close */
 +          pclose(fp);
 +        }
-+        g_iTotalSize = iTotalSize;
++        g_iTotalSize += iTotalSize;
 +    }
 +    /* END progress mod */
 +
  
    if (target_directory)
      {
-@@ -781,6 +858,46 @@
+@@ -781,6 +868,53 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -568,15 +578,22 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +        file_size_format ( s_copy_speed, copy_speed, 1 );
 +
 +        /* good-bye message */
-+        printf ( "%d files (%s) copied in %.1f seconds (%s/s).\n", g_iFilesCopied, sTotalWritten,
-+                 sec_elapsed, s_copy_speed );
++        char sFType[20];
++        if ( g_iDirectoriesCopied > 0 && g_iDirectoriesCopied == g_iFilesCopied )
++          sprintf ( sFType, "%s", "folder(s)" );
++        else if ( g_iDirectoriesCopied > 0 && g_iDirectoriesCopied < g_iFilesCopied )
++          sprintf ( sFType, "%s", "folder(s)/file(s)" );
++        else
++          sprintf ( sFType, "%s", "file(s)" );
++        printf ( "%d %s (%s) copied in %.1f seconds (%s/s).\n", g_iFilesCopied, sFType,
++                 sTotalWritten, sec_elapsed, s_copy_speed );
 +    }
 +    /* END progress mod */
 +
    return ok;
  }
  
-@@ -816,6 +933,7 @@
+@@ -816,6 +950,7 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
@@ -584,7 +601,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    x->set_mode = false;
    x->mode = 0;
  
-@@ -954,7 +1072,8 @@
+@@ -954,7 +1089,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -594,7 +611,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1011,6 +1130,12 @@
+@@ -1011,6 +1147,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
@@ -607,7 +624,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-@@ -1171,6 +1296,11 @@
+@@ -1171,6 +1313,11 @@
        usage (EXIT_FAILURE);
      }
  

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -364,7 +364,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2021-12-22 15:34:28.162542540 +0100
++++ coreutils-9.0-patched/src/copy.h	2021-12-22 22:30:16.072134557 +0100
 @@ -236,6 +236,9 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -375,7 +375,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -308,4 +311,17 @@
+@@ -308,4 +311,18 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
@@ -387,6 +387,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 +__attribute__((__common__)) long g_iTotalSize;
 +__attribute__((__common__)) long g_iTotalWritten;
 +__attribute__((__common__)) int g_iFilesCopied;
++__attribute__((__common__)) int g_iDirectoriesCopied;
 +__attribute__((__common__)) struct timeval g_oStartTime;
 +__attribute__((__common__)) int g_iTotalFiles;
 +__attribute__((__common__)) bool progress;
@@ -575,7 +576,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2021-12-22 18:29:46.254836707 +0100
++++ coreutils-9.0-patched/src/mv.c	2021-12-22 23:27:30.329010117 +0100
 @@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -584,7 +585,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -168,10 +169,87 @@
+@@ -168,10 +169,108 @@
  static bool
  do_move (char const *source, char const *dest, const struct cp_options *x)
  {
@@ -595,9 +596,17 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +
 +  /* BEGIN progress mod */
 +  if(progress && x->rename_errno != 0) {
-+    g_iTotalSize = 0;
-+    g_iFilesCopied = 0;
-+    g_iTotalWritten = 0;
++    if (g_iTotalSize == 0)
++      g_iTotalSize = 0;
++    if (g_iFilesCopied == 0)
++      g_iFilesCopied = 0;
++    if (g_iDirectoriesCopied == 0)
++      g_iDirectoriesCopied = 0;
++    if (g_iTotalWritten == 0)
++      g_iTotalWritten = 0;
++
++    if (target_directory_operand (source))
++      g_iDirectoriesCopied++;
 +
 +    gettimeofday (& start_time, NULL);
 +    g_oStartTime = start_time;
@@ -631,7 +640,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +
 +    /* close */
 +    pclose(fp);
-+    g_iTotalSize = iTotalSize;
++    g_iTotalSize += iTotalSize;
 +  }
 +  /* END progress mod */
 +
@@ -663,16 +672,29 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    char s_copy_speed[20];
 +    file_size_format ( s_copy_speed, copy_speed, 1 );
 +
++    /* increase counter */
++    g_iFilesCopied++;
++
 +    /* good-bye message */
-+    printf ( "%d files (%s) moved in %.1f seconds (%s/s).\n", g_iFilesCopied, sTotalWritten,
-+             sec_elapsed, s_copy_speed );
++    if ( x->last_file )
++    {
++      char sFType[20];
++      if ( g_iDirectoriesCopied > 0 && g_iDirectoriesCopied == g_iFilesCopied )
++        sprintf ( sFType, "%s", "folder(s)" );
++      else if ( g_iDirectoriesCopied > 0 && g_iDirectoriesCopied < g_iFilesCopied )
++        sprintf ( sFType, "%s", "folder(s)/file(s)" );
++      else
++        sprintf ( sFType, "%s", "file(s)" );
++      printf ( "%d %s (%s) moved in %.1f seconds (%s/s).\n", g_iFilesCopied, sFType,
++               sTotalWritten, sec_elapsed, s_copy_speed );
++    }
 +  }
 +  /* END progress mod */
 +
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +384,7 @@
+@@ -306,6 +405,7 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
@@ -680,7 +702,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +440,7 @@
+@@ -361,7 +461,7 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
@@ -689,7 +711,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
           != -1)
      {
        switch (c)
-@@ -407,6 +486,9 @@
+@@ -407,6 +507,9 @@
          case 'v':
            x.verbose = true;
            break;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-01-11 20:51:54.334645363 +0100
-@@ -129,6 +129,125 @@
++++ coreutils-9.0-patched/src/copy.c	2022-01-11 22:10:44.509858035 +0100
+@@ -129,6 +129,121 @@
    dev_t dev;
  };
  
@@ -39,7 +39,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  return _cEscapedString;
 +}
 +
-+char * format_time ( double seconds, bool showall )
++void format_time ( char * _cDest, double seconds, bool showall )
 +{
 +  // hours
 +  int hr = ( (int) seconds / (60 * 60)) % 24;
@@ -47,26 +47,22 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  int min = ( (int) seconds / 60) % 60;
 +  // seconds
 +  double sec = seconds - (hr * (60 * 60)) - (min * 60);
-+  size_t maxneeded = snprintf(NULL, 0, "%2dh %2dm %4.1fs", hr, min, sec) + 1;
-+  char * _cTimeString;
-+  _cTimeString = (char *) calloc( sizeof(char) * maxneeded, sizeof(char) );
 +  if ( showall )
 +  {
 +    if ( seconds < 0 )
-+      sprintf(_cTimeString, "%2ch %2cm %2cs", '0', '0', '?');
++      sprintf(_cDest, "%2ch %2cm %2cs", '0', '0', '?');
 +    else
-+      sprintf(_cTimeString, "%2dh %2dm %2ds", hr, min, (int) sec);
++      sprintf(_cDest, "%2dh %2dm %2ds", hr, min, (int) sec);
 +  } else  if ( seconds >= 3600 )
 +  {
-+    sprintf(_cTimeString, "%2dh %2dm %4.1fs", hr, min, sec);
++    sprintf(_cDest, "%2dh %2dm %4.1fs", hr, min, sec);
 +  } else if ( seconds >= 60 )
 +  {
-+    sprintf(_cTimeString, "%2dm %4.1fs", min, sec);
++    sprintf(_cDest, "%2dm %4.1fs", min, sec);
 +  } else
 +  {
-+    sprintf(_cTimeString, "%4.1fs", sec);
++    sprintf(_cDest, "%4.1fs", sec);
 +  }
-+  return _cTimeString;
 +}
 +
 +static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
@@ -127,7 +123,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -300,13 +419,28 @@
+@@ -300,13 +415,28 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes, bool allow_reflink,
@@ -157,7 +153,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* If not looking for holes, use copy_file_range if functional,
       but don't use if reflink disallowed as that may be implicit.  */
    if ((! hole_size) && allow_reflink && functional_copy_file_range ())
-@@ -362,6 +496,97 @@
+@@ -362,6 +492,103 @@
  
    while (max_n_read)
      {
@@ -198,17 +194,23 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +              * g_iFTotalSize ) - isec_felapsed;
 +            /* print out */
 +
++            char f_ttime[20];
++            char f_ftime[20];
++            format_time(f_ttime, sec_remaining, true);
++            format_time(f_ftime, sec_fremaining, true);
++
 +            sprintf ( s_progress->cProgressField[1],
 +              move_mode
 +                ? "%d of %d files moved (about %s remaining) "
 +                : "%d of %d files copied (about %s remaining) ",
-+                g_iFilesCopied, g_iTotalFiles, format_time(sec_remaining, true) );
++                g_iFilesCopied, g_iTotalFiles, f_ftime );
 +
-+            char s_ftime[100] = "";
++            char s_ftime[40] = "";
++
 +            if (g_iTotalFiles > 1)
-+              sprintf ( s_ftime, "(about %s remaining)", format_time(sec_fremaining, true) );
++              sprintf ( s_ftime, "(about %s remaining)", f_ftime );
 +            else
-+              sprintf ( s_ftime, "(about %s remaining)", format_time(sec_remaining, true) );
++              sprintf ( s_ftime, "(about %s remaining)", f_ttime );
 +
 +            sprintf ( s_progress->cProgressField[3],
 +              move_mode
@@ -255,7 +257,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +671,14 @@
+@@ -446,6 +673,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -270,7 +272,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -517,8 +750,16 @@
+@@ -517,8 +752,16 @@
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
              enum Sparse_type sparse_mode,
@@ -288,7 +290,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +831,26 @@
+@@ -590,10 +833,26 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -317,7 +319,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1631,82 @@
+@@ -1374,8 +1633,82 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -400,7 +402,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1714,30 @@
+@@ -1383,15 +1716,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -433,7 +435,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1748,14 @@
+@@ -1402,6 +1750,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -450,7 +452,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-01-11 20:51:54.334645363 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-01-11 22:10:44.509858035 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -469,7 +471,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  
 +/* BEGIN progress mod */
 +char * escape_double_quotes ( char * _cUnescapedString );
-+char * format_time ( double seconds, bool showall );
++void format_time ( char * _cDst, double seconds, bool showall );
 +
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
@@ -488,7 +490,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-01-11 20:51:54.338645406 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-01-11 22:10:44.513858084 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -597,7 +599,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
  
    if (target_directory)
      {
-@@ -781,6 +868,53 @@
+@@ -781,6 +868,56 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -643,15 +645,18 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +          sprintf ( sFType, "%s", "folder(s)/file(s)" );
 +        else
 +          sprintf ( sFType, "%s", "file(s)" );
++
++        char f_time[20];
++        format_time(f_time, sec_elapsed, true);
 +        printf ( "%d %s (%s) copied in %s (%s/s).\n", g_iFilesCopied, sFType,
-+                 sTotalWritten, format_time(sec_elapsed, false), s_copy_speed );
++                 sTotalWritten, f_time, s_copy_speed );
 +    }
 +    /* END progress mod */
 +
    return ok;
  }
  
-@@ -816,6 +950,11 @@
+@@ -816,6 +953,11 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
@@ -663,7 +668,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    x->set_mode = false;
    x->mode = 0;
  
-@@ -954,7 +1093,8 @@
+@@ -954,7 +1096,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -673,7 +678,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1011,6 +1151,12 @@
+@@ -1011,6 +1154,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
@@ -686,7 +691,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-@@ -1171,6 +1317,11 @@
+@@ -1171,6 +1320,11 @@
        usage (EXIT_FAILURE);
      }
  
@@ -700,7 +705,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-01-11 20:51:54.338645406 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-01-11 22:10:44.513858084 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -711,7 +716,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -170,8 +173,121 @@
+@@ -170,8 +173,124 @@
  {
    bool copy_into_self;
    bool rename_succeeded;
@@ -824,8 +829,11 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +        sprintf ( sFType, "%s", "folder(s)/file(s)" );
 +      else
 +        sprintf ( sFType, "%s", "file(s)" );
++
++      char f_time[20];
++      format_time(f_time, sec_elapsed, true);
 +      printf ( "%d %s (%s) moved in %s (%s/s).\n", g_iFilesCopied, sFType,
-+               sTotalWritten, format_time(sec_elapsed, false), s_copy_speed );
++               sTotalWritten, f_time, s_copy_speed );
 +    }
 +  }
 +  /* END progress mod */
@@ -833,7 +841,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +422,11 @@
+@@ -306,6 +425,11 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
@@ -845,7 +853,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +482,8 @@
+@@ -361,7 +485,8 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
@@ -855,7 +863,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
           != -1)
      {
        switch (c)
-@@ -407,6 +529,11 @@
+@@ -407,6 +532,11 @@
          case 'v':
            x.verbose = true;
            break;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-01-04 21:56:14.549035719 +0100
++++ coreutils-9.0-patched/src/copy.c	2022-01-09 21:12:20.602444195 +0100
 @@ -129,6 +129,119 @@
    dev_t dev;
  };
@@ -39,28 +39,28 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  return _cEscapedString;
 +}
 +
-+char * format_elapsed_time ( double sec_elapsed )
++char * format_time ( double seconds, bool showall )
 +{
 +  // hours
-+  long hr = ( (int) sec_elapsed / (60 * 60)) % 24;
++  int hr = ( (int) seconds / (60 * 60)) % 24;
 +  // minutes
-+  int min = ( (int) sec_elapsed / 60) % 60;
++  int min = ( (int) seconds / 60) % 60;
 +  // seconds
-+  double sec = sec_elapsed - (hr * (60 * 60)) - (min * 60);
-+  size_t maxneeded = snprintf(NULL, 0, "%ldh %dm %.1fs", hr, min, sec) + 1;
-+  char * _cElapsedTimeString;
-+  _cElapsedTimeString = (char *) calloc( sizeof(char) * maxneeded, sizeof(char) );
-+  if ( sec_elapsed >= 3600 )
++  double sec = seconds - (hr * (60 * 60)) - (min * 60);
++  size_t maxneeded = snprintf(NULL, 0, "%2dh %2dm %4.1fs", hr, min, sec) + 1;
++  char * _cTimeString;
++  _cTimeString = (char *) calloc( sizeof(char) * maxneeded, sizeof(char) );
++  if ( seconds >= 3600 || showall)
 +  {
-+    sprintf(_cElapsedTimeString, "%ldh %dm %.1fs", hr, min, sec);
-+  } else if ( sec_elapsed >= 60 )
++    sprintf(_cTimeString, "%2dh %2dm %4.1fs", hr, min, sec);
++  } else if ( seconds >= 60 )
 +  {
-+    sprintf(_cElapsedTimeString, "%dm %.1fs", min, sec);
++    sprintf(_cTimeString, "%2dm %4.1fs", min, sec);
 +  } else
 +  {
-+    sprintf(_cElapsedTimeString, "%.1fs", sec);
++    sprintf(_cTimeString, "%4.1fs", sec);
 +  }
-+  return _cElapsedTimeString;
++  return _cTimeString;
 +}
 +
 +static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
@@ -139,7 +139,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -362,6 +482,85 @@
+@@ -362,6 +482,81 @@
  
    while (max_n_read)
      {
@@ -174,16 +174,12 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +            int isec_elapsed = cur_time.tv_sec - g_oStartTime.tv_sec;
 +            int sec_remaining = ( int ) ( ( double ) isec_elapsed / cur_size
 +              * g_iTotalSize ) - isec_elapsed;
-+            int min_remaining = sec_remaining / 60;
-+            sec_remaining -= min_remaining * 60;
-+            int hours_remaining = min_remaining / 60;
-+            min_remaining -= hours_remaining * 60;
 +            /* print out */
 +            sprintf ( s_progress->cProgressField[3],
 +              move_mode
-+                ? "moving at %s/s (about %uh %um %us remaining)"
-+                : "copying at %s/s (about %uh %um %us remaining)", s_copy_speed,
-+              hours_remaining, min_remaining, sec_remaining );
++                ? "moving at %s/s (about %s remaining)"
++                : "copying at %s/s (about %s remaining)", s_copy_speed,
++              format_time(sec_remaining, true) );
 +
 +            int fs_len;
 +            if ( g_iTotalFiles > 1 )
@@ -225,7 +221,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +645,14 @@
+@@ -446,6 +641,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -240,7 +236,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -517,8 +724,16 @@
+@@ -517,8 +720,16 @@
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
              enum Sparse_type sparse_mode,
@@ -258,7 +254,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +805,26 @@
+@@ -590,10 +801,26 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -287,7 +283,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1605,82 @@
+@@ -1374,8 +1601,82 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -370,7 +366,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1688,30 @@
+@@ -1383,15 +1684,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -403,7 +399,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1722,14 @@
+@@ -1402,6 +1718,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -420,7 +416,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-01-04 21:56:14.553035790 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-01-09 21:12:20.602444195 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -439,7 +435,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  
 +/* BEGIN progress mod */
 +char * escape_double_quotes ( char * _cUnescapedString );
-+char * format_elapsed_time ( double sec_elapsed );
++char * format_time ( double seconds, bool showall );
 +
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
@@ -455,7 +451,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-01-04 21:56:14.553035790 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-01-09 21:12:20.606444248 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -611,7 +607,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +        else
 +          sprintf ( sFType, "%s", "file(s)" );
 +        printf ( "%d %s (%s) copied in %s (%s/s).\n", g_iFilesCopied, sFType,
-+                 sTotalWritten, format_elapsed_time(sec_elapsed), s_copy_speed );
++                 sTotalWritten, format_time(sec_elapsed, false), s_copy_speed );
 +    }
 +    /* END progress mod */
 +
@@ -667,7 +663,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-01-04 21:56:14.553035790 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-01-09 21:12:20.606444248 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -792,7 +788,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +      else
 +        sprintf ( sFType, "%s", "file(s)" );
 +      printf ( "%d %s (%s) moved in %s (%s/s).\n", g_iFilesCopied, sFType,
-+               sTotalWritten, format_elapsed_time(sec_elapsed), s_copy_speed );
++               sTotalWritten, format_time(sec_elapsed, false), s_copy_speed );
 +    }
 +  }
 +  /* END progress mod */

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-22 14:00:42.663699889 +0100
-@@ -129,6 +129,70 @@
++++ coreutils-9.0-patched/src/copy.c	2021-12-22 20:21:15.702583886 +0100
+@@ -129,6 +129,101 @@
    dev_t dev;
  };
  
@@ -14,6 +14,37 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +};
 +
 +/* BEGIN progress mod */
++char * escape_double_quotes ( char * _cUnescapedString )
++{
++  int pos = 0;
++  int count = 0;
++  for(pos = 0; _cUnescapedString[pos] != '\0'; pos++)
++  {
++    if(_cUnescapedString[pos] == '"')
++      ++count;
++  }
++
++  char * _cEscapedString;
++  _cEscapedString = calloc( sizeof(char) * ( pos + 1 + count * 2 ), sizeof(char) );
++
++  int epos = 0;
++  for(pos = 0; _cUnescapedString[pos] != '\0'; pos++)
++  {
++    if(_cUnescapedString[pos] == '"')
++    {
++      _cEscapedString[epos] = '\\';
++      epos++;
++      _cEscapedString[epos] = _cUnescapedString[pos];
++    }
++    else
++      _cEscapedString[epos] = _cUnescapedString[pos];
++    epos++;
++  }
++  epos++;
++  _cEscapedString[epos] = '\0';
++  return _cEscapedString;
++}
++
 +static void file_progress_bar ( char * _cDest, int _iBarLength, long _lProgress, long _lTotal )
 +{
 +    double dPercent = (double) _lProgress / (double) _lTotal * 100.f;
@@ -72,7 +103,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -299,10 +363,11 @@
+@@ -299,10 +394,11 @@
     bytes read.  */
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
@@ -86,7 +117,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -362,6 +427,85 @@
+@@ -362,6 +458,85 @@
  
    while (max_n_read)
      {
@@ -172,7 +203,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +590,14 @@
+@@ -446,6 +621,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -187,7 +218,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -516,9 +668,11 @@
+@@ -516,9 +699,11 @@
  static bool
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
@@ -201,7 +232,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +744,16 @@
+@@ -590,10 +775,16 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -220,7 +251,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1534,74 @@
+@@ -1374,8 +1565,74 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -295,7 +326,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1609,17 @@
+@@ -1383,15 +1640,17 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -316,7 +347,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1630,14 @@
+@@ -1402,6 +1661,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -333,7 +364,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2021-12-22 13:54:36.317440119 +0100
++++ coreutils-9.0-patched/src/copy.h	2021-12-22 15:34:28.162542540 +0100
 @@ -236,6 +236,9 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -344,11 +375,13 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -308,4 +311,15 @@
+@@ -308,4 +311,17 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
 +/* BEGIN progress mod */
++char * escape_double_quotes ( char * _cUnescapedString );
++
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
 +
 +__attribute__((__common__)) long g_iTotalSize;
@@ -362,7 +395,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2021-12-22 14:02:52.053943727 +0100
++++ coreutils-9.0-patched/src/cp.c	2021-12-22 18:28:14.781215839 +0100
 @@ -131,6 +131,7 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -381,7 +414,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -634,6 +638,70 @@
+@@ -634,6 +638,73 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
@@ -407,7 +440,9 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +
 +        /* how many files are we copying */
 +        char command[1024];
-+        sprintf( command, "find \"%s\" -type f | wc -l", file[0]);
++        char * _cEscapedString = escape_double_quotes( file[0] );
++        sprintf( command, "find \"%s\" -type f | wc -l", _cEscapedString );
++        free( _cEscapedString );
 +        FILE *fp ;
 +        char output[1024];
 +        fp = popen(command,"r");
@@ -421,8 +456,9 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +          /* call du -s for each file */
 +          /* create command */
 +          char command[1024];
-+          sprintf ( command, "du -s \"%s\"", file[j] );
-+          /* TODO: replace all quote signs in file[i] */
++          char * _cEscapedString = escape_double_quotes( file[j] );
++          sprintf ( command, "du -s \"%s\"", _cEscapedString );
++          free( _cEscapedString );
 +
 +          FILE *fp;
 +          char output[1024];
@@ -452,7 +488,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
  
    if (target_directory)
      {
-@@ -781,6 +849,46 @@
+@@ -781,6 +852,46 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -499,7 +535,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    return ok;
  }
  
-@@ -816,6 +924,7 @@
+@@ -816,6 +927,7 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
@@ -507,7 +543,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    x->set_mode = false;
    x->mode = 0;
  
-@@ -954,7 +1063,7 @@
+@@ -954,7 +1066,7 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -516,7 +552,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1011,6 +1120,10 @@
+@@ -1011,6 +1123,10 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
@@ -527,7 +563,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-@@ -1171,6 +1284,9 @@
+@@ -1171,6 +1287,9 @@
        usage (EXIT_FAILURE);
      }
  
@@ -539,7 +575,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2021-12-22 14:16:55.425936987 +0100
++++ coreutils-9.0-patched/src/mv.c	2021-12-22 18:29:46.254836707 +0100
 @@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -548,7 +584,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -168,10 +169,86 @@
+@@ -168,10 +169,87 @@
  static bool
  do_move (char const *source, char const *dest, const struct cp_options *x)
  {
@@ -572,8 +608,9 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    /* call du -s for each file */
 +    /* create command */
 +    char command[1024];
-+    sprintf ( command, "du -s \"%s\"", source );
-+    /* TODO: replace all quote signs in file[i] */
++    char * _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
++    sprintf ( command, "du -s \"%s\"", _cEscapedString );
++    free( _cEscapedString );
 +
 +    FILE *fp;
 +    char output[1024];
@@ -635,7 +672,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +383,7 @@
+@@ -306,6 +384,7 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
@@ -643,7 +680,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +439,7 @@
+@@ -361,7 +440,7 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
@@ -652,7 +689,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
           != -1)
      {
        switch (c)
-@@ -407,6 +485,9 @@
+@@ -407,6 +486,9 @@
          case 'v':
            x.verbose = true;
            break;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
-diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
+diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched-nc/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-02-14 21:04:58.552402945 +0100
++++ coreutils-9.0-patched-nc/src/copy.c	2022-02-14 21:14:14.183157065 +0100
 @@ -129,6 +129,133 @@
    dev_t dev;
  };
@@ -135,21 +135,17 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -300,13 +427,28 @@
+@@ -299,14 +426,23 @@
+    bytes read.  */
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
-              size_t hole_size, bool punch_holes, bool allow_reflink,
-+             /* BEGIN progress mod */
-+             bool move_mode,
-+             /* END progress mod */
+-             size_t hole_size, bool punch_holes, bool allow_reflink,
++             size_t hole_size, bool punch_holes, bool allow_reflink, bool move_mode,
               char const *src_name, char const *dst_name,
               uintmax_t max_n_read, off_t *total_n_read,
 -             bool *last_write_made_hole)
-+             bool *last_write_made_hole
-+             /* BEGIN progress mod */
-+             , struct progress_status *s_progress
-+             /* END progress mod */
-+             )
++             bool *last_write_made_hole,
++             struct progress_status *s_progress)
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
@@ -165,7 +161,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* If not looking for holes, use copy_file_range if functional,
       but don't use if reflink disallowed as that may be implicit.  */
    if ((! hole_size) && allow_reflink && functional_copy_file_range ())
-@@ -362,6 +504,103 @@
+@@ -362,6 +498,103 @@
  
    while (max_n_read)
      {
@@ -269,7 +265,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +685,14 @@
+@@ -446,6 +679,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -284,54 +280,40 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -517,8 +764,16 @@
+@@ -516,9 +757,11 @@
+ static bool
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
-             enum Sparse_type sparse_mode,
-+            /* BEGIN progress mod */
-+            bool move_mode,
-+            /* END progress mod */
+-            enum Sparse_type sparse_mode,
++            enum Sparse_type sparse_mode, bool move_mode,
              bool allow_reflink,
 -            char const *src_name, char const *dst_name)
-+            char const *src_name, char const *dst_name
-+            /* BEGIN progress mod */
-+            , int iCountDown, char ** cProgressField, struct timeval last_time,
-+            int last_size, int iBarLength, struct stat src_open_sb
-+            /* END progress mod */
-+            )
++            char const *src_name, char const *dst_name,
++            int iCountDown, char ** cProgressField, struct timeval last_time,
++            int last_size, int iBarLength, struct stat src_open_sb)
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +845,26 @@
+@@ -590,10 +833,16 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
 +
-+      /* BEGIN progress mod */
 +      struct timeval a;
 +      struct stat b;
 +
 +      struct progress_status s_progress={iCountDown, cProgressField, last_time, last_size, iBarLength, src_open_sb};
-+      /* END progress mod */
 +
        if ( ! sparse_copy (src_fd, dest_fd, buf, buf_size,
                            sparse_mode == SPARSE_NEVER ? 0 : hole_size,
 -                          true, allow_reflink, src_name, dst_name,
 -                          ext_len, &n_read, &read_hole))
-+                          true, allow_reflink,
-+                          /* BEGIN progress mod */
-+                          move_mode,
-+                          /* END progress mod */
-+                          src_name, dst_name,
-+                          ext_len, &n_read, &read_hole
-+                          /* BEGIN progress mod */
-+                          , &s_progress
-+                          /* END progress mod */
-+                          ))
++                          true, allow_reflink, move_mode, src_name,
++                          dst_name, ext_len, &n_read, &read_hole, &s_progress))
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1645,82 @@
+@@ -1374,8 +1623,80 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -407,47 +389,33 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        off_t n_read;
        bool wrote_hole_at_eof = false;
 +
-+      /* BEGIN progress mod */
 +      struct progress_status s_progress = { iCountDown, cProgressField, last_time, last_size, iBarLength, src_open_sb};
-+      /* END progress mod */
 +
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1728,30 @@
+@@ -1383,15 +1704,17 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
 -                           src_name, dst_name)
-+                           /* BEGIN progress mod */
-+                           x->move_mode,
-+                           /* END progress mod */
-+                           src_name, dst_name
-+                           /* BEGIN progress mod */
-+                           , iCountDown, cProgressField, last_time, last_size,
-+                           iBarLength, src_open_sb
-+                           /* END progress mod */
-+                           )
++                           x->move_mode, src_name, dst_name,
++                           iCountDown, cProgressField, last_time, last_size,
++                           iBarLength, src_open_sb)
               :
  #endif
               sparse_copy (source_desc, dest_desc, buf, buf_size,
                              make_holes ? hole_size : 0,
                              x->sparse_mode == SPARSE_ALWAYS,
                              x->reflink_mode != REFLINK_NEVER,
-+                            /* BEGIN progress mod */
-+                            x->move_mode,
-+                            /* END progress mod */
-                             src_name, dst_name, UINTMAX_MAX, &n_read,
+-                            src_name, dst_name, UINTMAX_MAX, &n_read,
 -                            &wrote_hole_at_eof)))
-+                            &wrote_hole_at_eof
-+                            /* BEGIN progress mod */
-+                            , &s_progress
-+                            /* END progress mod */
-+                            )))
++                            x->move_mode, src_name, dst_name, UINTMAX_MAX,
++                            &n_read, &wrote_hole_at_eof, &s_progress)))
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1762,14 @@
+@@ -1402,6 +1725,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -462,22 +430,20 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
      }
  
    if (x->preserve_timestamps)
-diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
+diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched-nc/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-02-14 21:04:58.564403350 +0100
-@@ -236,6 +236,11 @@
++++ coreutils-9.0-patched-nc/src/copy.h	2022-02-14 21:14:14.183157065 +0100
+@@ -236,6 +236,9 @@
       Create destination directories as usual. */
    bool symbolic_link;
  
-+  /* BEGIN progress mod */
 +  /* If true, draw a nice progress bar on screen */
 +  bool progress_bar;
-+  /* END progress mod */
 +
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -308,4 +313,22 @@
+@@ -308,4 +311,22 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
@@ -500,34 +466,28 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 +/* END progress mod */
 +
  #endif
-diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
+diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched-nc/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-02-14 21:04:58.572403620 +0100
-@@ -131,6 +131,9 @@
++++ coreutils-9.0-patched-nc/src/cp.c	2022-02-14 21:14:14.183157065 +0100
+@@ -131,6 +131,7 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
-+  /* BEGIN progress mod */
 +  {"progress-bar", no_argument, NULL, 'g'},
-+  /* END progress mod */
    {"verbose", no_argument, NULL, 'v'},
    {GETOPT_SELINUX_CONTEXT_OPTION_DECL},
    {GETOPT_HELP_OPTION_DECL},
-@@ -170,6 +173,13 @@
+@@ -170,6 +171,9 @@
    -f, --force                  if an existing destination file cannot be\n\
                                   opened, remove it and try again (this option\n\
                                   is ignored when the -n option is also used)\n\
-+"), stdout); /* BEGIN progress mod - remove the complete line!*/
-+      fputs (_("\
 +  -g, --progress-bar           add a progress bar.\n\
 +                                 Note that this doesn't work with reflink,\n\
 +                                 reflink will be automatically disabled\n\
-+"), stdout);
-+/* END progress mod - remove the complete line!*/ fputs (_("\
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -634,6 +644,84 @@
+@@ -634,6 +638,84 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
@@ -612,7 +572,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
  
    if (target_directory)
      {
-@@ -781,6 +869,56 @@
+@@ -781,6 +863,56 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -669,19 +629,17 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    return ok;
  }
  
-@@ -816,6 +954,11 @@
+@@ -816,6 +948,9 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
 +
-+  /* BEGIN progress mod */
 +  x->progress_bar = false;
-+  /* END progress mod */
 +
    x->set_mode = false;
    x->mode = 0;
  
-@@ -954,7 +1097,8 @@
+@@ -954,7 +1089,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -691,45 +649,39 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1011,6 +1155,12 @@
+@@ -1011,6 +1147,10 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
-+        /* BEGIN progress mod */
 +        case 'g':
 +          progress = true;
 +          break;
-+        /* END progress mod */
 +
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-@@ -1171,6 +1321,11 @@
+@@ -1171,6 +1311,9 @@
        usage (EXIT_FAILURE);
      }
  
-+  /* BEGIN progress mod */
 +  if (progress)
 +    x.reflink_mode = REFLINK_NEVER;
-+  /* END progress mod */
 +
    x.backup_type = (make_backups
                     ? xget_version (_("backup type"),
                                     version_control_string)
-diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
+diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched-nc/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-02-14 21:04:58.580403890 +0100
-@@ -66,6 +66,9 @@
++++ coreutils-9.0-patched-nc/src/mv.c	2022-02-14 21:14:14.183157065 +0100
+@@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
    {"verbose", no_argument, NULL, 'v'},
-+  /* BEGIN progress mod */
 +  {"progress-bar", no_argument, NULL, 'g'},
-+  /* END progress mod */
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -170,8 +173,130 @@
+@@ -170,8 +171,130 @@
  {
    bool copy_into_self;
    bool rename_succeeded;
@@ -860,37 +812,30 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +431,11 @@
+@@ -306,6 +429,7 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
-+"), stdout); /* BEGIN progress mod - remove the complete line!*/
-+fputs (_("\
 +  -g, --progress-bar           add progress-bar\n\
-+"), stdout);
-+/* END progress mod - remove the complete line!*/ fputs (_("\
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +491,8 @@
+@@ -361,7 +485,7 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
 -  while ((c = getopt_long (argc, argv, "bfint:uvS:TZ", long_options, NULL))
-+  /* BEGIN and END progress mod - remove the g in the next line!*/
 +  while ((c = getopt_long (argc, argv, "bfint:uvgS:TZ", long_options, NULL))
           != -1)
      {
        switch (c)
-@@ -407,6 +538,11 @@
+@@ -407,6 +531,9 @@
          case 'v':
            x.verbose = true;
            break;
-+        /* BEGIN progress mod */
 +        case 'g':
 +          progress = true;
 +          break;
-+        /* END progress mod */
          case 'S':
            make_backups = true;
            backup_suffix = optarg;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,7 +1,7 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-01-11 23:26:31.735507217 +0100
-@@ -129,6 +129,121 @@
++++ coreutils-9.0-patched/src/copy.c	2022-02-13 13:20:13.643469909 +0100
+@@ -129,6 +129,133 @@
    dev_t dev;
  };
  
@@ -14,29 +14,41 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +  struct stat src_open_sb;
 +};
 +
-+char * escape_double_quotes ( char * _cUnescapedString )
++FILE * spawn( const char *cmd, char *const argv[] )
 +{
-+  char * _cEscapedString;
-+  _cEscapedString = (char *) calloc( sizeof(char) * strlen(_cUnescapedString) * 2, sizeof(char) );
-+  size_t ipos = 0;
-+  size_t rpos = 0;
-+  for(rpos = 0, ipos = 0; _cUnescapedString[rpos] != '\0'; rpos++, ipos++)
-+  {
-+    if(_cUnescapedString[rpos] == '"')
-+    {
-+      _cEscapedString[ipos] = '\\';
-+      ipos++;
++    FILE *ret = NULL;
++    int pfd_read[2];
++    pid_t pid;
++
++    if (cmd == NULL || argv == NULL)
++        return ret;
++
++    if (pipe(pfd_read) < 0) {
++        error(0, errno, "pipe: %s", cmd);
++        return ret;
 +    }
-+    if(_cUnescapedString[rpos] == '`')
-+    {
-+      _cEscapedString[ipos] = '\\';
-+      ipos++;
++
++    if ((pid = fork()) == 0) {
++        int err = dup2(pfd_read[1], 1) < 0;
++        close(pfd_read[0]);
++        close(pfd_read[1]);
++
++        if (err)
++            error(EXIT_FAILURE, errno, "dup2: %s", cmd);
++        execvp(cmd, argv);
++        error(EXIT_FAILURE, errno, "exec: %s", cmd);
 +    }
-+    _cEscapedString[ipos] = _cUnescapedString[rpos];
-+  }
-+  ipos++;
-+  _cEscapedString[ipos] = '\0';
-+  return _cEscapedString;
++
++    close(pfd_read[1]);
++
++    if (pid < 0) {
++        close(pfd_read[0]);
++        error(0, errno, "fork: %s", cmd);
++        return ret;
++    }
++
++    ret = fdopen(pfd_read[0], "r");
++    return ret;
 +}
 +
 +void format_time ( char * _cDest, double seconds, bool showall )
@@ -123,7 +135,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -300,13 +415,28 @@
+@@ -300,13 +427,28 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, bool punch_holes, bool allow_reflink,
@@ -153,7 +165,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* If not looking for holes, use copy_file_range if functional,
       but don't use if reflink disallowed as that may be implicit.  */
    if ((! hole_size) && allow_reflink && functional_copy_file_range ())
-@@ -362,6 +492,103 @@
+@@ -362,6 +504,103 @@
  
    while (max_n_read)
      {
@@ -257,7 +269,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +673,14 @@
+@@ -446,6 +685,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -272,7 +284,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -517,8 +752,16 @@
+@@ -517,8 +764,16 @@
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
              enum Sparse_type sparse_mode,
@@ -290,7 +302,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +833,26 @@
+@@ -590,10 +845,26 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -319,7 +331,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1633,82 @@
+@@ -1374,8 +1645,82 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -402,7 +414,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1716,30 @@
+@@ -1383,15 +1728,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -435,7 +447,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1750,14 @@
+@@ -1402,6 +1762,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -452,7 +464,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-01-11 23:26:31.739507270 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-02-13 13:20:13.643469909 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -470,7 +482,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  mode_t cached_umask (void);
  
 +/* BEGIN progress mod */
-+char * escape_double_quotes ( char * _cUnescapedString );
++FILE * spawn( const char *cmd, char *const argv[] );
 +void format_time ( char * _cDst, double seconds, bool showall );
 +
 +int file_size_format ( char * _cDst, long _lSize, int _iCounter );
@@ -490,7 +502,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-01-11 23:26:31.743507323 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-02-13 13:20:13.647469904 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -515,7 +527,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -634,6 +644,83 @@
+@@ -634,6 +644,84 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
@@ -549,33 +561,34 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +        int j;
 +
 +        /* how many files are we copying */
-+        char command[1024];
-+        char * _cEscapedString = escape_double_quotes( file[0] );
-+        sprintf( command, "find \"%s\" -type f | wc -l", _cEscapedString );
-+        free( _cEscapedString );
 +        FILE *fp ;
 +        char output[1024];
-+        fp = popen(command,"r");
-+        if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
++        char fcmd[] = "find";
++        fp = spawn(fcmd, (char *[]){ fcmd, file[0], NULL, "-type", "f", NULL });
++        if ( fp == NULL)
 +            printf("failed to run find\r");
 +        else
-+            if ( atoi(output) > n_files )
-+              g_iTotalFiles = atoi( output );
++        {
++          char *line_buf = NULL;
++          size_t line_buf_size = 0;
++          int line_count = 0;
++          ssize_t line_size;
++          line_size = getline(&line_buf, &line_buf_size, fp);
++          while (line_size > 0)
++          {
++              line_count++;
++              line_size = getline(&line_buf, &line_buf_size, fp);
++          }
++          free (line_buf);
++          if ( line_count > n_files )
++            g_iTotalFiles = line_count;
++        }
 +
 +        for (j = 0; j < iFiles; j++)
 +        {
 +          /* call du -s for each file */
-+          /* create command */
-+          char command[1024];
-+          char * _cEscapedString = escape_double_quotes( file[j] );
-+          sprintf ( command, "du -s \"%s\"", _cEscapedString );
-+          free( _cEscapedString );
-+
-+          FILE *fp;
-+          char output[1024];
-+
-+          /* run command */
-+          fp = popen(command, "r");
++          char dcmd[] = "du";
++          fp = spawn(dcmd, (char *[]){ dcmd, "-s", file[j], NULL });
 +          if (fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL) {
 +            printf("failed to run du\r" );
 +          }
@@ -599,7 +612,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
  
    if (target_directory)
      {
-@@ -781,6 +868,56 @@
+@@ -781,6 +869,56 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -656,7 +669,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    return ok;
  }
  
-@@ -816,6 +953,11 @@
+@@ -816,6 +954,11 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
@@ -668,7 +681,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    x->set_mode = false;
    x->mode = 0;
  
-@@ -954,7 +1096,8 @@
+@@ -954,7 +1097,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -678,7 +691,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1011,6 +1154,12 @@
+@@ -1011,6 +1155,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
@@ -691,7 +704,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-@@ -1171,6 +1320,11 @@
+@@ -1171,6 +1321,11 @@
        usage (EXIT_FAILURE);
      }
  
@@ -705,7 +718,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-01-11 23:26:31.743507323 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-02-13 13:20:13.647469904 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -716,7 +729,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -170,8 +173,124 @@
+@@ -170,8 +173,130 @@
  {
    bool copy_into_self;
    bool rename_succeeded;
@@ -743,30 +756,36 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    g_oStartTime = start_time;
 +
 +    /* how many files are we copying */
-+    char command[1024];
-+    char output[1024];
 +    FILE *fp ;
-+
-+    char * _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
-+    sprintf( command, "find \"%s\" -type f | wc -l", _cEscapedString );
-+    free( _cEscapedString );
-+    fp = popen(command,"r");
-+    if ( fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL)
++    char output[1024];
++    char fcmd[] = "find";
++    fp = spawn(fcmd, (char *[]){ fcmd, (unsigned char *)(size_t)source, NULL, "-type", "f", NULL });
++    if ( fp == NULL)
 +      printf("failed to run find\r");
 +    else
-+      g_iTotalFiles = atoi( output );
++    {
++      char *line_buf = NULL;
++      size_t line_buf_size = 0;
++      int line_count = 0;
++      ssize_t line_size;
++      line_size = getline(&line_buf, &line_buf_size, fp);
++      while (line_size > 0)
++      {
++        line_count++;
++        line_size = getline(&line_buf, &line_buf_size, fp);
++      }
++      free (line_buf);
++      g_iTotalFiles = line_count;
++    }
++    /* close */
++    pclose(fp);
 +
 +    printf ("calculating total size... \r");
 +    fflush (stdout);
 +    long iTotalSize = 0;
 +    /* call du -s for each file */
-+    /* create command */
-+    _cEscapedString = escape_double_quotes( (unsigned char *)(size_t)source );
-+    sprintf ( command, "du -s \"%s\"", _cEscapedString );
-+    free( _cEscapedString );
-+
-+    /* run command */
-+    fp = popen(command, "r");
++    char dcmd[] = "du";
++    fp = spawn(dcmd, (char *[]){ dcmd, "-s", (unsigned char *)(size_t)source, NULL });
 +    if (fp == NULL || fgets(output, sizeof(output)-1, fp) == NULL) {
 +      printf("failed to run du\r" );
 +    }
@@ -841,7 +860,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +425,11 @@
+@@ -306,6 +431,11 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
@@ -853,7 +872,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +485,8 @@
+@@ -361,7 +491,8 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
@@ -863,7 +882,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
           != -1)
      {
        switch (c)
-@@ -407,6 +532,11 @@
+@@ -407,6 +538,11 @@
          case 'v':
            x.verbose = true;
            break;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-02-13 13:20:13.643469909 +0100
++++ coreutils-9.0-patched/src/copy.c	2022-02-13 16:09:25.450003849 +0100
 @@ -129,6 +129,133 @@
    dev_t dev;
  };
@@ -464,7 +464,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-02-13 13:20:13.643469909 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-02-13 16:09:25.454003885 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -502,7 +502,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-02-13 13:20:13.647469904 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-02-13 16:09:25.454003885 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -660,7 +660,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +          sprintf ( sFType, "%s", "file(s)" );
 +
 +        char f_time[20];
-+        format_time(f_time, sec_elapsed, true);
++        format_time(f_time, sec_elapsed, false);
 +        printf ( "%d %s (%s) copied in %s (%s/s).\n", g_iFilesCopied, sFType,
 +                 sTotalWritten, f_time, s_copy_speed );
 +    }
@@ -718,7 +718,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-02-13 13:20:13.647469904 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-02-13 16:09:25.458003920 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -850,7 +850,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +        sprintf ( sFType, "%s", "file(s)" );
 +
 +      char f_time[20];
-+      format_time(f_time, sec_elapsed, true);
++      format_time(f_time, sec_elapsed, false);
 +      printf ( "%d %s (%s) moved in %s (%s/s).\n", g_iFilesCopied, sFType,
 +               sTotalWritten, f_time, s_copy_speed );
 +    }

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-02-13 16:09:25.450003849 +0100
++++ coreutils-9.0-patched/src/copy.c	2022-02-14 21:04:58.552402945 +0100
 @@ -129,6 +129,133 @@
    dev_t dev;
  };
@@ -464,7 +464,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-02-13 16:09:25.454003885 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-02-14 21:04:58.564403350 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -502,7 +502,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-02-13 16:09:25.454003885 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-02-14 21:04:58.572403620 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -564,7 +564,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 +        FILE *fp ;
 +        char output[1024];
 +        char fcmd[] = "find";
-+        fp = spawn(fcmd, (char *[]){ fcmd, file[0], NULL, "-type", "f", NULL });
++        fp = spawn(fcmd, (char *[]){ fcmd, file[0], "-type", "f", NULL });
 +        if ( fp == NULL)
 +            printf("failed to run find\r");
 +        else
@@ -718,7 +718,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-02-13 16:09:25.458003920 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-02-14 21:04:58.580403890 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
@@ -759,7 +759,7 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 +    FILE *fp ;
 +    char output[1024];
 +    char fcmd[] = "find";
-+    fp = spawn(fcmd, (char *[]){ fcmd, (unsigned char *)(size_t)source, NULL, "-type", "f", NULL });
++    fp = spawn(fcmd, (char *[]){ fcmd, (char *)source, "-type", "f", NULL });
 +    if ( fp == NULL)
 +      printf("failed to run find\r");
 +    else

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-01-04 21:09:38.656916500 +0100
++++ coreutils-9.0-patched/src/copy.c	2022-01-04 21:56:14.549035719 +0100
 @@ -129,6 +129,119 @@
    dev_t dev;
  };
@@ -420,7 +420,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-01-04 21:09:38.660916566 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-01-04 21:56:14.553035790 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -455,7 +455,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-01-04 21:09:38.660916566 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-01-04 21:56:14.553035790 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -618,15 +618,19 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    return ok;
  }
  
-@@ -816,6 +950,7 @@
+@@ -816,6 +950,11 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
++
++  /* BEGIN progress mod */
 +  x->progress_bar = false;
++  /* END progress mod */
++
    x->set_mode = false;
    x->mode = 0;
  
-@@ -954,7 +1089,8 @@
+@@ -954,7 +1093,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
@@ -636,7 +640,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                             long_opts, NULL))
           != -1)
      {
-@@ -1011,6 +1147,12 @@
+@@ -1011,6 +1151,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
@@ -649,7 +653,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-@@ -1171,6 +1313,11 @@
+@@ -1171,6 +1317,11 @@
        usage (EXIT_FAILURE);
      }
  
@@ -663,7 +667,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-01-04 21:09:38.660916566 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-01-04 21:56:14.553035790 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2021-12-23 09:03:07.290374485 +0100
++++ coreutils-9.0-patched/src/copy.c	2021-12-23 11:35:19.632502471 +0100
 @@ -129,6 +129,101 @@
    dev_t dev;
  };
@@ -103,21 +103,25 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -299,10 +394,11 @@
-    bytes read.  */
+@@ -300,9 +395,16 @@
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
--             size_t hole_size, bool punch_holes, bool allow_reflink,
-+             size_t hole_size, bool punch_holes, bool allow_reflink, bool move_mode,
+              size_t hole_size, bool punch_holes, bool allow_reflink,
++             /* BEGIN progress mod */
++             bool move_mode,
++             /* END progress mod */
               char const *src_name, char const *dst_name,
               uintmax_t max_n_read, off_t *total_n_read,
 -             bool *last_write_made_hole)
-+             bool *last_write_made_hole,
-+             struct progress_status *s_progress)
++             bool *last_write_made_hole
++             /* BEGIN progress mod */
++             , struct progress_status *s_progress
++             /* END progress mod */
++             )
  {
    *last_write_made_hole = false;
    *total_n_read = 0;
-@@ -362,6 +458,85 @@
+@@ -362,6 +464,85 @@
  
    while (max_n_read)
      {
@@ -203,7 +207,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +621,14 @@
+@@ -446,6 +627,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -218,40 +222,54 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -516,9 +699,11 @@
- static bool
+@@ -517,8 +706,16 @@
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
--            enum Sparse_type sparse_mode,
-+            enum Sparse_type sparse_mode, bool move_mode,
+             enum Sparse_type sparse_mode,
++            /* BEGIN progress mod */
++            bool move_mode,
++            /* END progress mod */
              bool allow_reflink,
 -            char const *src_name, char const *dst_name)
-+            char const *src_name, char const *dst_name,
-+            int iCountDown, char ** cProgressField, struct timeval last_time,
-+            int last_size, int iBarLength, struct stat src_open_sb)
++            char const *src_name, char const *dst_name
++            /* BEGIN progress mod */
++            , int iCountDown, char ** cProgressField, struct timeval last_time,
++            int last_size, int iBarLength, struct stat src_open_sb
++            /* END progress mod */
++            )
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +775,16 @@
+@@ -590,10 +787,26 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
 +
++      /* BEGIN progress mod */
 +      struct timeval a;
 +      struct stat b;
 +
 +      struct progress_status s_progress={iCountDown, cProgressField, last_time, last_size, iBarLength, src_open_sb};
++      /* END progress mod */
 +
        if ( ! sparse_copy (src_fd, dest_fd, buf, buf_size,
                            sparse_mode == SPARSE_NEVER ? 0 : hole_size,
 -                          true, allow_reflink, src_name, dst_name,
 -                          ext_len, &n_read, &read_hole))
-+                          true, allow_reflink, move_mode, src_name,
-+                          dst_name, ext_len, &n_read, &read_hole, &s_progress))
++                          true, allow_reflink,
++                          /* BEGIN progress mod */
++                          move_mode,
++                          /* END progress mod */
++                          src_name, dst_name,
++                          ext_len, &n_read, &read_hole
++                          /* BEGIN progress mod */
++                          , &s_progress
++                          /* END progress mod */
++                          ))
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1565,74 @@
+@@ -1374,8 +1587,78 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -322,32 +340,48 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +
        off_t n_read;
        bool wrote_hole_at_eof = false;
++
++      /* BEGIN progress mod */
 +      struct progress_status s_progress = { iCountDown, cProgressField, last_time, last_size, iBarLength, src_open_sb};
++      /* END progress mod */
++
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1640,17 @@
+@@ -1383,15 +1666,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
 -                           src_name, dst_name)
-+                           x->move_mode, src_name, dst_name,
-+                           iCountDown, cProgressField, last_time, last_size,
-+                           iBarLength, src_open_sb)
++                           /* BEGIN progress mod */
++                           x->move_mode,
++                           /* END progress mod */
++                           src_name, dst_name
++                           /* BEGIN progress mod */
++                           , iCountDown, cProgressField, last_time, last_size,
++                           iBarLength, src_open_sb
++                           /* END progress mod */
++                           )
               :
  #endif
               sparse_copy (source_desc, dest_desc, buf, buf_size,
                              make_holes ? hole_size : 0,
                              x->sparse_mode == SPARSE_ALWAYS,
                              x->reflink_mode != REFLINK_NEVER,
--                            src_name, dst_name, UINTMAX_MAX, &n_read,
++                            /* BEGIN progress mod */
++                            x->move_mode,
++                            /* END progress mod */
+                             src_name, dst_name, UINTMAX_MAX, &n_read,
 -                            &wrote_hole_at_eof)))
-+                            x->move_mode, src_name, dst_name, UINTMAX_MAX,
-+                             &n_read, &wrote_hole_at_eof, &s_progress)))
++                            &wrote_hole_at_eof
++                            /* BEGIN progress mod */
++                            , &s_progress
++                            /* END progress mod */
++                            )))
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1661,14 @@
+@@ -1402,6 +1700,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -364,18 +398,20 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2021-12-22 22:30:16.072134557 +0100
-@@ -236,6 +236,9 @@
++++ coreutils-9.0-patched/src/copy.h	2021-12-23 09:37:38.015722020 +0100
+@@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
  
++  /* BEGIN progress mod */
 +  /* If true, draw a nice progress bar on screen */
 +  bool progress_bar;
++  /* END progress mod */
 +
    /* If true, do not copy a nondirectory that has an existing destination
       with the same or newer modification time. */
    bool update;
-@@ -308,4 +311,18 @@
+@@ -308,4 +313,18 @@
  bool chown_failure_ok (struct cp_options const *) _GL_ATTRIBUTE_PURE;
  mode_t cached_umask (void);
  
@@ -396,26 +432,32 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2021-12-22 18:28:14.781215839 +0100
-@@ -131,6 +131,7 @@
++++ coreutils-9.0-patched/src/cp.c	2021-12-23 11:44:06.012603217 +0100
+@@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
++  /* BEGIN progress mod */
 +  {"progress-bar", no_argument, NULL, 'g'},
++  /* END progress mod */
    {"verbose", no_argument, NULL, 'v'},
    {GETOPT_SELINUX_CONTEXT_OPTION_DECL},
    {GETOPT_HELP_OPTION_DECL},
-@@ -170,6 +171,9 @@
+@@ -170,6 +173,13 @@
    -f, --force                  if an existing destination file cannot be\n\
                                   opened, remove it and try again (this option\n\
                                   is ignored when the -n option is also used)\n\
++"), stdout); /* BEGIN progress mod - remove the complete line!*/
++      fputs (_("\
 +  -g, --progress-bar           add a progress bar.\n\
 +                                 Note that this doesn't work with reflink,\n\
 +                                 reflink will be automatically disabled\n\
++"), stdout);
++/* END progress mod - remove the complete line!*/ fputs (_("\
    -i, --interactive            prompt before overwrite (overrides a previous -n\
  \n\
                                    option)\n\
-@@ -634,6 +638,73 @@
+@@ -634,6 +644,73 @@
          die (EXIT_FAILURE, 0, _("target %s is not a directory"),
               quoteaf (file[n_files - 1]));
      }
@@ -489,7 +531,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
  
    if (target_directory)
      {
-@@ -781,6 +852,46 @@
+@@ -781,6 +858,46 @@
        ok = copy (source, new_dest, 0, x, &unused, NULL);
      }
  
@@ -536,7 +578,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    return ok;
  }
  
-@@ -816,6 +927,7 @@
+@@ -816,6 +933,7 @@
    x->recursive = false;
    x->sparse_mode = SPARSE_AUTO;
    x->symbolic_link = false;
@@ -544,57 +586,62 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
    x->set_mode = false;
    x->mode = 0;
  
-@@ -954,7 +1066,7 @@
+@@ -954,7 +1072,8 @@
    selinux_enabled = (0 < is_selinux_enabled ());
    cp_option_init (&x);
  
 -  while ((c = getopt_long (argc, argv, "abdfHilLnprst:uvxPRS:TZ",
++  /* BEGIN and END progress mod - remove the g in the next line!*/
 +  while ((c = getopt_long (argc, argv, "abdfgHilLnprst:uvxPRS:TZ",
                             long_opts, NULL))
           != -1)
      {
-@@ -1011,6 +1123,10 @@
+@@ -1011,6 +1130,12 @@
            x.unlink_dest_after_failed_open = true;
            break;
  
++        /* BEGIN progress mod */
 +        case 'g':
 +          progress = true;
 +          break;
++        /* END progress mod */
 +
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-@@ -1171,6 +1287,9 @@
+@@ -1171,6 +1296,11 @@
        usage (EXIT_FAILURE);
      }
  
++  /* BEGIN progress mod */
 +  if (progress)
 +    x.reflink_mode = REFLINK_NEVER;
++  /* END progress mod */
 +
    x.backup_type = (make_backups
                     ? xget_version (_("backup type"),
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2021-12-22 23:27:30.329010117 +0100
-@@ -66,6 +66,7 @@
++++ coreutils-9.0-patched/src/mv.c	2021-12-23 11:57:51.221688967 +0100
+@@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},
    {"verbose", no_argument, NULL, 'v'},
++  /* BEGIN progress mod */
 +  {"progress-bar", no_argument, NULL, 'g'},
++  /* END progress mod */
    {GETOPT_HELP_OPTION_DECL},
    {GETOPT_VERSION_OPTION_DECL},
    {NULL, 0, NULL, 0}
-@@ -168,10 +169,108 @@
- static bool
- do_move (char const *source, char const *dest, const struct cp_options *x)
+@@ -170,8 +173,106 @@
  {
-+  struct timeval start_time;
-+
    bool copy_into_self;
    bool rename_succeeded;
 +
 +  /* BEGIN progress mod */
++  struct timeval start_time;
++
 +  if(progress && x->rename_errno != 0) {
 +    if (g_iTotalSize == 0)
 +      g_iTotalSize = 0;
@@ -694,30 +741,37 @@ diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
    if (ok)
      {
        char const *dir_to_remove;
-@@ -306,6 +405,7 @@
+@@ -306,6 +407,11 @@
  \n\
    -b                           like --backup but does not accept an argument\n\
    -f, --force                  do not prompt before overwriting\n\
++"), stdout); /* BEGIN progress mod - remove the complete line!*/
++fputs (_("\
 +  -g, --progress-bar           add progress-bar\n\
++"), stdout);
++/* END progress mod - remove the complete line!*/ fputs (_("\
    -i, --interactive            prompt before overwrite\n\
    -n, --no-clobber             do not overwrite an existing file\n\
  If you specify more than one of -i, -f, -n, only the final one takes effect.\n\
-@@ -361,7 +461,7 @@
+@@ -361,7 +467,8 @@
    /* Try to disable the ability to unlink a directory.  */
    priv_set_remove_linkdir ();
  
 -  while ((c = getopt_long (argc, argv, "bfint:uvS:TZ", long_options, NULL))
++  /* BEGIN and END progress mod - remove the g in the next line!*/
 +  while ((c = getopt_long (argc, argv, "bfint:uvgS:TZ", long_options, NULL))
           != -1)
      {
        switch (c)
-@@ -407,6 +507,9 @@
+@@ -407,6 +514,11 @@
          case 'v':
            x.verbose = true;
            break;
++        /* BEGIN progress mod */
 +        case 'g':
 +          progress = true;
 +          break;
++        /* END progress mod */
          case 'S':
            make_backups = true;
            backup_suffix = optarg;

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 --- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.c	2022-01-09 21:12:20.602444195 +0100
++++ coreutils-9.0-patched/src/copy.c	2022-01-09 21:17:53.190781361 +0100
 @@ -129,6 +129,119 @@
    dev_t dev;
  };
@@ -283,7 +283,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1601,82 @@
+@@ -1374,8 +1601,84 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -324,9 +324,11 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +        /* show how many files were written */
 +        int sum_length = 0;
 +        if ( x->move_mode )
-+          sum_length = sprintf ( cProgressField[1], "%d files moved so far...", g_iFilesCopied );
++          sum_length = sprintf ( cProgressField[1], "%d of %d files moved so far...",
++            g_iFilesCopied, g_iTotalFiles );
 +        else
-+          sum_length = sprintf ( cProgressField[1], "%d files copied so far...", g_iFilesCopied );
++          sum_length = sprintf ( cProgressField[1], "%d of %d files copied so far...",
++            g_iFilesCopied, g_iTotalFiles );
 +        cProgressField[1][sum_length] = ' ';
 +      }
 +
@@ -366,7 +368,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1684,30 @@
+@@ -1383,15 +1686,30 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -399,7 +401,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1718,14 @@
+@@ -1402,6 +1720,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -416,7 +418,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 --- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/copy.h	2022-01-09 21:12:20.602444195 +0100
++++ coreutils-9.0-patched/src/copy.h	2022-01-09 21:17:53.194781413 +0100
 @@ -236,6 +236,11 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -451,7 +453,7 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
 --- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/cp.c	2022-01-09 21:12:20.606444248 +0100
++++ coreutils-9.0-patched/src/cp.c	2022-01-09 21:17:53.194781413 +0100
 @@ -131,6 +131,9 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -663,7 +665,7 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
 --- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
-+++ coreutils-9.0-patched/src/mv.c	2022-01-09 21:12:20.606444248 +0100
++++ coreutils-9.0-patched/src/mv.c	2022-01-09 21:17:53.194781413 +0100
 @@ -66,6 +66,9 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},


### PR DESCRIPTION
I think I was finally able to fix the double quotes (and grave accent) problem. Also included are some improvements I had proposed before, but were never accepted. I did the changes for my fork and plan to keep them. This PR is for you to have a look at what I have done and maybe merge the pieces you would like to include.

The edec49e commit is not working correctly (files/folders with grave accented names are still broken)  The final function is in 
a620f86. edit: I had to switch back to using calloc instead of malloc (see commit message cf51b9b for more detail).