### PR TITLE
fix progressbars not showing when moving files and global progress

### DIFF
--- a/advcpmv-0.8-8.32.patch
+++ b/advcpmv-0.8-8.32.patch
@@ -1,6 +1,6 @@
-diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
+diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched/src/copy.c
 --- coreutils-8.32/src/copy.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched-nc/src/copy.c	2022-02-14 21:14:14.171156659 +0100
++++ coreutils-8.32-patched/src/copy.c	2022-04-03 21:03:04.869415222 +0200
 @@ -129,6 +129,133 @@
    dev_t dev;
  };
@@ -135,7 +135,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
  /* Initial size of the cp.dest_info hash table.  */
  #define DEST_INFO_INITIAL_CAPACITY 61
  
-@@ -258,18 +385,124 @@
+@@ -258,18 +385,125 @@
     bytes read.  */
  static bool
  sparse_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
@@ -204,11 +204,13 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
 +            format_time(f_ttime, sec_remaining, true);
 +            format_time(f_ftime, sec_fremaining, true);
 +
-+            sprintf ( s_progress->cProgressField[1],
++            int fs_len;
++            fs_len = sprintf ( s_progress->cProgressField[1],
 +              move_mode
-+                ? "%d of %d files moved (about %s remaining) "
-+                : "%d of %d files copied (about %s remaining) ",
++                ? "%d of %d files moved (about %s remaining)"
++                : "%d of %d files copied (about %s remaining)",
 +                g_iFilesCopied, g_iTotalFiles, f_ttime );
++            s_progress->cProgressField[1][fs_len] = ' ';
 +
 +            char s_ftime[40] = "";
 +
@@ -222,7 +224,6 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
 +                ? "moving at %s/s %s"
 +                : "copying at %s/s %s", s_copy_speed, s_ftime );
 +
-+            int fs_len;
 +            if ( g_iTotalFiles > 1 )
 +            {
 +              /* global progress bar */
@@ -262,7 +263,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -354,6 +587,14 @@
+@@ -354,6 +588,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -277,7 +278,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -420,9 +661,11 @@
+@@ -420,9 +662,11 @@
  static bool
  extent_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
               size_t hole_size, off_t src_total_size,
@@ -291,7 +292,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
  {
    struct extent_scan scan;
    off_t last_ext_start = 0;
-@@ -553,10 +796,16 @@
+@@ -553,10 +797,16 @@
                last_ext_len = ext_len;
                bool read_hole;
  
@@ -310,7 +311,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
                  goto fail;
  
                dest_pos = ext_start + n_read;
-@@ -1305,6 +1554,75 @@
+@@ -1305,6 +1555,75 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -386,7 +387,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
        if (sparse_src)
          {
            bool normal_copy_required;
-@@ -1316,7 +1634,9 @@
+@@ -1316,7 +1635,9 @@
            if (extent_copy (source_desc, dest_desc, buf, buf_size, hole_size,
                             src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
@@ -397,7 +398,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
              goto preserve_metadata;
  
            if (! normal_copy_required)
-@@ -1328,11 +1648,14 @@
+@@ -1328,11 +1649,14 @@
  
        off_t n_read;
        bool wrote_hole_at_eof;
@@ -415,7 +416,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1343,6 +1666,12 @@
+@@ -1343,6 +1667,12 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -428,7 +429,7 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
      }
  
  preserve_metadata:
-@@ -1716,15 +2045,15 @@
+@@ -1716,15 +2046,15 @@
        fprintf (stderr,
                 (x->move_mode || x->unlink_dest_before_opening
                  || x->unlink_dest_after_failed_open)
@@ -447,9 +448,9 @@ diff -aur coreutils-8.32/src/copy.c coreutils-8.32-patched-nc/src/copy.c
                 program_name, quoteaf (dst_name));
      }
  
-diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched-nc/src/copy.h
+diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched/src/copy.h
 --- coreutils-8.32/src/copy.h	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched-nc/src/copy.h	2022-02-14 21:14:14.175156795 +0100
++++ coreutils-8.32-patched/src/copy.h	2022-04-03 21:03:04.873415280 +0200
 @@ -234,6 +234,9 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -483,9 +484,9 @@ diff -aur coreutils-8.32/src/copy.h coreutils-8.32-patched-nc/src/copy.h
 +/* END progress mod */
 +
  #endif
-diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched-nc/src/cp.c
+diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched/src/cp.c
 --- coreutils-8.32/src/cp.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched-nc/src/cp.c	2022-02-14 21:14:14.175156795 +0100
++++ coreutils-8.32-patched/src/cp.c	2022-04-03 21:03:04.873415280 +0200
 @@ -131,6 +131,7 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -674,9 +675,9 @@ diff -aur coreutils-8.32/src/cp.c coreutils-8.32-patched-nc/src/cp.c
          case 'H':
            x.dereference = DEREF_COMMAND_LINE_ARGUMENTS;
            break;
-diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched-nc/src/mv.c
+diff -aur coreutils-8.32/src/mv.c coreutils-8.32-patched/src/mv.c
 --- coreutils-8.32/src/mv.c	2020-01-01 15:13:12.000000000 +0100
-+++ coreutils-8.32-patched-nc/src/mv.c	2022-02-14 21:14:14.175156795 +0100
++++ coreutils-8.32-patched/src/mv.c	2022-04-03 21:03:04.873415280 +0200
 @@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},

--- a/advcpmv-0.9-9.0.patch
+++ b/advcpmv-0.9-9.0.patch
@@ -1,6 +1,6 @@
 diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
---- coreutils-9.0/src/copy.c	2021-09-24 17:01:05.000000000 +0530
-+++ coreutils-9.0-patched/src/copy.c	2022-03-27 05:54:15.840209369 +0530
+--- coreutils-9.0/src/copy.c	2021-09-24 13:31:05.000000000 +0200
++++ coreutils-9.0-patched/src/copy.c	2022-04-03 21:03:04.881415398 +0200
 @@ -129,6 +129,133 @@
    dev_t dev;
  };
@@ -161,7 +161,128 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* If not looking for holes, use copy_file_range if functional,
       but don't use if reflink disallowed as that may be implicit.  */
    if ((! hole_size) && allow_reflink && functional_copy_file_range ())
-@@ -362,6 +498,103 @@
+@@ -317,8 +453,105 @@
+            surely aligned well.  */
+         ssize_t ssize_max = TYPE_MAXIMUM (ssize_t);
+         ptrdiff_t copy_max = MIN (ssize_max, SIZE_MAX) >> 30 << 30;
++
++        /* BEGIN progress mod */
++        if (progress) {
++          /* update countdown */
++          s_progress->iCountDown--;
++          char * sProgressBar = s_progress->cProgressField[5];
++          if ( s_progress->iCountDown < 0 )
++            s_progress->iCountDown = 100;
++
++          /* just print one line with the percentage, but not always */
++          if ( s_progress->iCountDown == 0 )
++          {
++            /* calculate current speed */
++            struct timeval cur_time;
++            gettimeofday ( & cur_time, NULL );
++            int cur_size = g_iTotalWritten + *total_n_read / 1024;
++            int cur_fsize = g_iFTotalWritten + *total_n_read / 1024;
++            int usec_elapsed = cur_time.tv_usec - s_progress->last_time.tv_usec;
++            double sec_elapsed = ( double ) usec_elapsed / 1000000.f;
++            sec_elapsed += ( double ) ( cur_time.tv_sec - s_progress->last_time.tv_sec );
++            int copy_speed = ( int ) ( ( double ) ( cur_size - s_progress->last_size )
++              / sec_elapsed );
++            char s_copy_speed[20];
++            file_size_format ( s_copy_speed, copy_speed >= 0 ? copy_speed : 0, 1 );
++            /* update vars */
++            s_progress->last_time = cur_time;
++            s_progress->last_size = cur_size;
++
++            /* how many time has passed since the start? */
++            int isec_elapsed = cur_time.tv_sec - g_oStartTime.tv_sec;
++            int isec_felapsed = cur_time.tv_sec - g_oFStartTime.tv_sec;
++            int sec_remaining = ( int ) ( ( double ) isec_elapsed / cur_size
++              * g_iTotalSize ) - isec_elapsed;
++            int sec_fremaining = ( int ) ( ( double ) isec_felapsed / cur_fsize
++              * g_iFTotalSize ) - isec_felapsed;
++            /* print out */
++
++            char f_ttime[20];
++            char f_ftime[20];
++            format_time(f_ttime, sec_remaining, true);
++            format_time(f_ftime, sec_fremaining, true);
++
++            int fs_len;
++            fs_len = sprintf ( s_progress->cProgressField[1],
++              move_mode
++                ? "%d of %d files moved (about %s remaining)"
++                : "%d of %d files copied (about %s remaining)",
++                g_iFilesCopied, g_iTotalFiles, f_ttime );
++            s_progress->cProgressField[1][fs_len] = ' ';
++
++            char s_ftime[40] = "";
++
++            if (g_iTotalFiles > 1)
++              sprintf ( s_ftime, "(about %s remaining)", f_ftime );
++            else
++              sprintf ( s_ftime, "(about %s remaining)", f_ttime );
++
++            if ( g_iTotalFiles > 1 )
++            {
++              /* global progress bar */
++              file_progress_bar ( s_progress->cProgressField[2], s_progress->iBarLength,
++                                  g_iTotalWritten + *total_n_read / 1024, g_iTotalSize );
++
++              /* print the global status */
++              fs_len = file_size_format ( s_progress->cProgressField[1] + s_progress->iBarLength - 21,
++                                              g_iTotalWritten + *total_n_read / 1024, 1 );
++              s_progress->cProgressField[1][s_progress->iBarLength - 21 + fs_len] = ' ';
++            }
++
++            /* set current progress bar to be always 100 % */
++            file_progress_bar ( sProgressBar, s_progress->iBarLength, s_progress->src_open_sb.st_size, s_progress->src_open_sb.st_size );
++            s_progress->cProgressField[5][s_progress->iBarLength-2] = '0';
++            s_progress->cProgressField[5][s_progress->iBarLength-1] = '%';
++            s_progress->cProgressField[5][s_progress->iBarLength] = '\0';
++
++            /* print the status as always full filesize*/
++            fs_len = file_size_format ( s_progress->cProgressField[4] + s_progress->iBarLength - 21, s_progress->src_open_sb.st_size, 0 );
++            s_progress->cProgressField[4][s_progress->iBarLength - 21 + fs_len] = ' ';
++
++            /* print the field */
++            int it;
++            for ( it = g_iTotalFiles>1 ? 0 : 3; it < 6; it++ )
++            {
++              printf ( "\033[K%s\n", s_progress->cProgressField[it] );
++              if ( strlen ( s_progress->cProgressField[it] ) < s_progress->iBarLength )
++                printf ( "%s", "" );
++            }
++            if ( g_iTotalFiles > 1 )
++              printf ( "\r\033[6A" );
++            else
++              printf ( "\r\033[3A" );
++            fflush ( stdout );
++          }
++        }
++        /* END progress mod */
++
+         ssize_t n_copied = copy_file_range (src_fd, NULL, dest_fd, NULL,
+                                             MIN (max_n_read, copy_max), 0);
++
+         if (n_copied == 0)
+           {
+             /* copy_file_range incorrectly returns 0 when reading from
+@@ -355,6 +588,14 @@
+           }
+         max_n_read -= n_copied;
+         *total_n_read += n_copied;
++
++        /* BEGIN progress mod */
++        if (progress) {
++          /* update total size */
++          g_iTotalWritten += *total_n_read / 1024;
++          g_iFilesCopied++;
++        }
++        /* END progress mod */
+       }
+ 
+   bool make_hole = false;
+@@ -362,6 +603,104 @@
  
    while (max_n_read)
      {
@@ -207,11 +328,13 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +            format_time(f_ttime, sec_remaining, true);
 +            format_time(f_ftime, sec_fremaining, true);
 +
-+            sprintf ( s_progress->cProgressField[1],
++            int fs_len;
++            fs_len = sprintf ( s_progress->cProgressField[1],
 +              move_mode
-+                ? "%d of %d files moved (about %s remaining) "
-+                : "%d of %d files copied (about %s remaining) ",
++                ? "%d of %d files moved (about %s remaining)"
++                : "%d of %d files copied (about %s remaining)",
 +                g_iFilesCopied, g_iTotalFiles, f_ttime );
++            s_progress->cProgressField[1][fs_len] = ' ';
 +
 +            char s_ftime[40] = "";
 +
@@ -225,7 +348,6 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
 +                ? "moving at %s/s %s"
 +                : "copying at %s/s %s", s_copy_speed, s_ftime );
 +
-+            int fs_len;
 +            if ( g_iTotalFiles > 1 )
 +            {
 +              /* global progress bar */
@@ -265,7 +387,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        ssize_t n_read = read (src_fd, buf, MIN (max_n_read, buf_size));
        if (n_read < 0)
          {
-@@ -446,6 +679,14 @@
+@@ -446,6 +785,14 @@
           certain files in /proc or /sys with linux kernels.  */
      }
  
@@ -280,7 +402,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
    /* Ensure a trailing hole is created, so that subsequent
       calls of sparse_copy() start at the correct offset.  */
    if (make_hole && ! create_hole (dest_fd, dst_name, punch_holes, psize))
-@@ -516,9 +757,11 @@
+@@ -516,9 +863,11 @@
  static bool
  lseek_copy (int src_fd, int dest_fd, char *buf, size_t buf_size,
              size_t hole_size, off_t ext_start, off_t src_total_size,
@@ -294,7 +416,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  {
    off_t last_ext_start = 0;
    off_t last_ext_len = 0;
-@@ -590,10 +833,16 @@
+@@ -590,10 +939,16 @@
           is conservative and may miss some holes.  */
        off_t n_read;
        bool read_hole;
@@ -313,7 +435,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          return false;
  
        dest_pos = ext_start + n_read;
-@@ -1374,8 +1623,80 @@
+@@ -1374,8 +1729,80 @@
        buf_alloc = xmalloc (buf_size + buf_alignment);
        buf = ptr_align (buf_alloc, buf_alignment);
  
@@ -394,7 +516,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
        if (! (
  #ifdef SEEK_HOLE
               scantype == LSEEK_SCANTYPE
-@@ -1383,15 +1704,17 @@
+@@ -1383,15 +1810,17 @@
                             scan_inference.ext_start, src_open_sb.st_size,
                             make_holes ? x->sparse_mode : SPARSE_NEVER,
                             x->reflink_mode != REFLINK_NEVER,
@@ -415,7 +537,7 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
          {
            return_val = false;
            goto close_src_and_dst_desc;
-@@ -1402,6 +1725,14 @@
+@@ -1402,6 +1831,14 @@
            return_val = false;
            goto close_src_and_dst_desc;
          }
@@ -431,8 +553,8 @@ diff -aur coreutils-9.0/src/copy.c coreutils-9.0-patched/src/copy.c
  
    if (x->preserve_timestamps)
 diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
---- coreutils-9.0/src/copy.h	2021-09-24 17:01:05.000000000 +0530
-+++ coreutils-9.0-patched/src/copy.h	2022-03-27 05:54:15.844209471 +0530
+--- coreutils-9.0/src/copy.h	2021-09-24 13:31:05.000000000 +0200
++++ coreutils-9.0-patched/src/copy.h	2022-04-03 21:03:04.881415398 +0200
 @@ -236,6 +236,9 @@
       Create destination directories as usual. */
    bool symbolic_link;
@@ -467,8 +589,8 @@ diff -aur coreutils-9.0/src/copy.h coreutils-9.0-patched/src/copy.h
 +
  #endif
 diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
---- coreutils-9.0/src/cp.c	2021-09-24 17:01:05.000000000 +0530
-+++ coreutils-9.0-patched/src/cp.c	2022-03-27 06:28:53.896713403 +0530
+--- coreutils-9.0/src/cp.c	2021-09-24 13:31:05.000000000 +0200
++++ coreutils-9.0-patched/src/cp.c	2022-04-03 21:03:04.885415457 +0200
 @@ -131,6 +131,7 @@
    {"symbolic-link", no_argument, NULL, 's'},
    {"target-directory", required_argument, NULL, 't'},
@@ -669,8 +791,8 @@ diff -aur coreutils-9.0/src/cp.c coreutils-9.0-patched/src/cp.c
                     ? xget_version (_("backup type"),
                                     version_control_string)
 diff -aur coreutils-9.0/src/mv.c coreutils-9.0-patched/src/mv.c
---- coreutils-9.0/src/mv.c	2021-09-24 17:01:05.000000000 +0530
-+++ coreutils-9.0-patched/src/mv.c	2022-03-27 06:38:49.800838574 +0530
+--- coreutils-9.0/src/mv.c	2021-09-24 13:31:05.000000000 +0200
++++ coreutils-9.0-patched/src/mv.c	2022-04-03 21:03:04.885415457 +0200
 @@ -66,6 +66,7 @@
    {"target-directory", required_argument, NULL, 't'},
    {"update", no_argument, NULL, 'u'},


### PR DESCRIPTION
Coreutils 9.0 introduced an additional copy/move mechanism using the copy_file_range system call, that wasn't handled by our patch. The result was the progress bars not showing, whenever the new mechanism is used. This fix duplicates the relevant code to the new location, so the new method is handled, too.

Maybe at a later stage this can be refactored to call a single function which contains the code for both mechanisms instead of duplicating it.

While investigating I noticed I had introduced a problem where the global size progress was not shown anymore. The reason was  not removing the string terminator from a smaller string when injecting it into a larger one, so the end of the larger string got truncated and not output anymore. This should be fixed now, too.