### PR TITLE
replace wget with curl in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,12 @@ set -e
 ADVCPMV_VERSION=${1:-0.9}
 CORE_UTILS_VERSION=${2:-9.0}
 
-wget http://ftp.gnu.org/gnu/coreutils/coreutils-$CORE_UTILS_VERSION.tar.xz
+curl -LO http://ftp.gnu.org/gnu/coreutils/coreutils-$CORE_UTILS_VERSION.tar.xz
 tar xvJf coreutils-$CORE_UTILS_VERSION.tar.xz
 rm coreutils-$CORE_UTILS_VERSION.tar.xz
 (
     cd coreutils-$CORE_UTILS_VERSION/
-    wget https://raw.githubusercontent.com/jarun/advcpmv/master/advcpmv-$ADVCPMV_VERSION-$CORE_UTILS_VERSION.patch
+    curl -LO https://raw.githubusercontent.com/jarun/advcpmv/master/advcpmv-$ADVCPMV_VERSION-$CORE_UTILS_VERSION.patch
     patch -p1 -i advcpmv-$ADVCPMV_VERSION-$CORE_UTILS_VERSION.patch
     ./configure
     make


### PR DESCRIPTION
Curl is present by default as git depends on it. Wget needs to be installed separately on some distros.