### PR TITLE
switch install script from HTTP to HTTPS for tarball

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -e
 ADVCPMV_VERSION=${1:-0.9}
 CORE_UTILS_VERSION=${2:-9.5}
 
-curl -LO http://ftp.gnu.org/gnu/coreutils/coreutils-$CORE_UTILS_VERSION.tar.xz
+curl -LO https://ftp.gnu.org/gnu/coreutils/coreutils-$CORE_UTILS_VERSION.tar.xz
 tar xvJf coreutils-$CORE_UTILS_VERSION.tar.xz
 rm coreutils-$CORE_UTILS_VERSION.tar.xz
 (


### PR DESCRIPTION
Rather than verifying signatures, switching to "https://ftp..." removes any insecure connections entirely.