### PR TITLE
Fix Fish shell alias command syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ echo -e 'alias mv=\x27/usr/local/bin/mvg -g\x27' >> ~/.bashrc
 Fish:
 
 ```
-echo alias cp '/usr/local/bin/advcp -g' >> ~/.config/fish/config.fish
-echo alias mv '/usr/local/bin/advmv -g' >> ~/.config/fish/config.fish
+echo "alias cp '/usr/local/bin/advcp -g'" >> ~/.config/fish/config.fish
+echo "alias mv '/usr/local/bin/advmv -g'" >> ~/.config/fish/config.fish
 ```
 
 ```


### PR DESCRIPTION
Previously, when running in a fish shell, single quotes around arguments were stripped, causing the command to break. This change wraps the line in double quotes to preserve the single quotes when writing to the configuration file.